### PR TITLE
Improve delete functionality

### DIFF
--- a/install/helm/synopsys-operator/templates/operator.yaml
+++ b/install/helm/synopsys-operator/templates/operator.yaml
@@ -72,7 +72,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-config
 data:
-  config.json: '{"OperatorTimeBombInSeconds":"315576000","HubDeletionWaitTimeInSeconds":"31557600", "DryRun": false, "LogLevel": "debug", "Namespace": {{ quote .Release.Namespace }}, "Threadiness": 5, "PostgresRestartInMins": 10, "NFSPath" : "/kubenfs", "HubFederatorConfig": {"HubConfig": {"User": {{ quote .Values.bdConfig.adminUsername }}, "PasswordEnvVar": "HUB_PASSWORD", "ClientTimeoutMilliseconds": 5000, "Port": 443, "FetchAllProjectsPauseSeconds": 60}, "UseMockMode": false, "Port": 3016, "Registry": "gcr.io", "ImagePath": "saas-hub-stg/blackducksoftware", "ImageName": "federator", "ImageVersion": "master"}}'
+  config.json: '{"OperatorTimeBombInSeconds":"315576000", "DryRun": false, "LogLevel": "debug", "Namespace": {{ quote .Release.Namespace }}, "Threadiness": 5, "PostgresRestartInMins": 10, "NFSPath" : "/kubenfs", "HubFederatorConfig": {"HubConfig": {"User": {{ quote .Values.bdConfig.adminUsername }}, "PasswordEnvVar": "HUB_PASSWORD", "ClientTimeoutMilliseconds": 5000, "Port": 443, "FetchAllProjectsPauseSeconds": 60}, "UseMockMode": false, "Port": 3016, "Registry": "gcr.io", "ImagePath": "saas-hub-stg/blackducksoftware", "ImageName": "federator", "ImageVersion": "master"}}'
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/install/synopsys-operator.yaml
+++ b/install/synopsys-operator.yaml
@@ -79,7 +79,7 @@ items:
   metadata:
     name: synopsys-operator
   data:
-    config.json: '{"OperatorTimeBombInSeconds":"315576000","HubDeletionWaitTimeInSeconds":"31557600", "DryRun": false, "LogLevel": "debug", "Namespace": "${NAMESPACE}", "Threadiness": 5, "PostgresRestartInMins": 10, "NFSPath" : "/kubenfs", "HubFederatorConfig": {"HubConfig": {"User": "sysadmin", "PasswordEnvVar": "HUB_PASSWORD", "ClientTimeoutMilliseconds": 5000, "Port": 443, "FetchAllProjectsPauseSeconds": 60}, "UseMockMode": false, "Port": 3016, "Registry": "gcr.io", "ImagePath": "saas-hub-stg/blackducksoftware", "ImageName": "federator", "ImageVersion": "master"}}'
+    config.json: '{"OperatorTimeBombInSeconds":"315576000", "DryRun": false, "LogLevel": "debug", "Namespace": "${NAMESPACE}", "Threadiness": 5, "PostgresRestartInMins": 10, "NFSPath" : "/kubenfs", "HubFederatorConfig": {"HubConfig": {"User": "sysadmin", "PasswordEnvVar": "HUB_PASSWORD", "ClientTimeoutMilliseconds": 5000, "Port": 443, "FetchAllProjectsPauseSeconds": 60}, "UseMockMode": false, "Port": 3016, "Registry": "gcr.io", "ImagePath": "saas-hub-stg/blackducksoftware", "ImageName": "federator", "ImageVersion": "master"}}'
 - apiVersion: v1
   kind: ServiceAccount
   metadata:

--- a/pkg/hub/creater.go
+++ b/pkg/hub/creater.go
@@ -59,31 +59,10 @@ func NewCreater(config *protoform.Config, kubeConfig *rest.Config, kubeClient *k
 	return &Creater{Config: config, KubeConfig: kubeConfig, KubeClient: kubeClient, HubClient: hubClient, osSecurityClient: osSecurityClient, routeClient: routeClient}
 }
 
-// BeCareful makes sure we dont delete hubs instantly.  Logic is subject to change over time.
-func (hc *Creater) BeCareful() error {
-	// A wait time of >= one year is our way of saying "deletion disabled"
-	if hc.Config.HubDeletionWaitTimeInSeconds > 31557600 {
-		return fmt.Errorf("Deletion appears disabled (wait time is %v seconds)! Set HubDeletionWaitTimeInSeconds in protoforms configuration if you really want to automatically delete hubs", hc.Config.HubDeletionWaitTimeInSeconds)
-	}
+// DeleteHub will delete the Black Duck Hub
+func (hc *Creater) DeleteHub(namespace string) error {
 
-	waitTime := time.Duration(hc.Config.HubDeletionWaitTimeInSeconds) * time.Second
-
-	logrus.Infof("Waiting %v till we delete !!!", waitTime)
-	// Now wait... , we never want to just delete immediately.
-	time.Sleep(waitTime)
-	logrus.Infof("Done waiting for deletion ! Ready to delete now.")
-	// ok, ready to delete now !
-	return nil
-}
-
-// DeleteHubCarefully will delete the Black Duck Hub IF IT MATCHES THE DELETION REGEX, and only then.
-func (hc *Creater) DeleteHubCarefully(namespace string) error {
-
-	logrus.Infof("Delete hub request %v, will be careful (%v)", namespace, hc.Config.HubDeletionWaitTimeInSeconds)
-	// blocking call intentionally, we dont want to rush to DELETE a hub.
-	if err := hc.BeCareful(); err != nil {
-		return err
-	}
+	logrus.Infof("Deleting hub: %s", namespace)
 
 	var err error
 	// Verify whether the namespace exist

--- a/pkg/protoform/config.go
+++ b/pkg/protoform/config.go
@@ -31,14 +31,13 @@ import (
 
 // Config type will be used for protoform config that bootstraps everything
 type Config struct {
-	DryRun                       bool
-	LogLevel                     string
-	Namespace                    string
-	Threadiness                  int
-	PostgresRestartInMins        int
-	NFSPath                      string
-	HubFederatorConfig           *HubFederatorConfig
-	HubDeletionWaitTimeInSeconds int64
+	DryRun                bool
+	LogLevel              string
+	Namespace             string
+	Threadiness           int
+	PostgresRestartInMins int
+	NFSPath               string
+	HubFederatorConfig    *HubFederatorConfig
 
 	// Not recommended production, just for testing, QA, resiliency, and CI/CD.
 	OperatorTimeBombInSeconds int64
@@ -48,7 +47,6 @@ type Config struct {
 func (config *Config) SelfSetDefaults() {
 	config.HubFederatorConfig = &HubFederatorConfig{}
 	config.HubFederatorConfig.HubConfig = &HubConfig{}
-	config.HubDeletionWaitTimeInSeconds = math.MaxInt64
 	config.OperatorTimeBombInSeconds = math.MaxInt64
 }
 


### PR DESCRIPTION
Remove the HubDeletionWaitTimeInSeconds workaround and instead, check the CRD state to figure out if the hub is manually (and intentionally) deleted. 