### PR TITLE
add tests for ctl_blackduck

### DIFF
--- a/pkg/alert/ctl_alert_test.go
+++ b/pkg/alert/ctl_alert_test.go
@@ -84,17 +84,17 @@ func TestSwitchSpec(t *testing.T) {
 
 	var tests = []struct {
 		input    string
-		expected alertv1.AlertSpec
+		expected *alertv1.AlertSpec
 	}{
-		{input: "empty", expected: alertv1.AlertSpec{}},
-		{input: "spec1", expected: *crddefaults.GetAlertDefaultValue()},
-		{input: "spec2", expected: *crddefaults.GetAlertDefaultValue2()},
+		{input: "empty", expected: &alertv1.AlertSpec{}},
+		{input: "spec1", expected: crddefaults.GetAlertDefaultValue()},
+		{input: "spec2", expected: crddefaults.GetAlertDefaultValue2()},
 	}
 
 	// test cases: "empty", "spec1", "spec2"
 	for _, test := range tests {
 		assert.Nil(alertCtl.SwitchSpec(test.input))
-		assert.Equal(test.expected, alertCtl.GetSpec())
+		assert.Equal(*test.expected, alertCtl.GetSpec())
 	}
 
 	// test cases: default
@@ -111,23 +111,23 @@ func TestAddSpecFlags(t *testing.T) {
 	actualCmd := &cobra.Command{}
 	ctl.AddSpecFlags(actualCmd)
 
-	expectedCmd := &cobra.Command{}
-	expectedCmd.Flags().StringVar(&ctl.Registry, "alert-registry", ctl.Registry, "Registry with the Alert Image")
-	expectedCmd.Flags().StringVar(&ctl.ImagePath, "image-path", ctl.ImagePath, "Path to the Alert Image")
-	expectedCmd.Flags().StringVar(&ctl.AlertImageName, "alert-image-name", ctl.AlertImageName, "Name of the Alert Image")
-	expectedCmd.Flags().StringVar(&ctl.AlertImageVersion, "alert-image-version", ctl.AlertImageVersion, "Version of the Alert Image")
-	expectedCmd.Flags().StringVar(&ctl.CfsslImageName, "cfssl-image-name", ctl.CfsslImageName, "Name of Cfssl Image")
-	expectedCmd.Flags().StringVar(&ctl.CfsslImageVersion, "cfssl-image-version", ctl.CfsslImageVersion, "Version of Cffsl Image")
-	expectedCmd.Flags().StringVar(&ctl.BlackduckHost, "blackduck-host", ctl.BlackduckHost, "Host url of Blackduck")
-	expectedCmd.Flags().StringVar(&ctl.BlackduckUser, "blackduck-user", ctl.BlackduckUser, "Username for Blackduck")
-	expectedCmd.Flags().IntVar(&ctl.BlackduckPort, "blackduck-port", ctl.BlackduckPort, "Port for Blackduck")
-	expectedCmd.Flags().IntVar(&ctl.Port, "port", ctl.Port, "Port for Alert")
-	expectedCmd.Flags().BoolVar(&ctl.StandAlone, "stand-alone", ctl.StandAlone, "Enable Stand Alone mode")
-	expectedCmd.Flags().StringVar(&ctl.AlertMemory, "alert-memory", ctl.AlertMemory, "Memory allocation for the Alert")
-	expectedCmd.Flags().StringVar(&ctl.CfsslMemory, "cfssl-memory", ctl.CfsslMemory, "Memory allocation for the Cfssl")
-	expectedCmd.Flags().StringVar(&ctl.DesiredState, "alert-desired-state", ctl.DesiredState, "State of the Alert")
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&ctl.Registry, "alert-registry", ctl.Registry, "Registry with the Alert Image")
+	cmd.Flags().StringVar(&ctl.ImagePath, "image-path", ctl.ImagePath, "Path to the Alert Image")
+	cmd.Flags().StringVar(&ctl.AlertImageName, "alert-image-name", ctl.AlertImageName, "Name of the Alert Image")
+	cmd.Flags().StringVar(&ctl.AlertImageVersion, "alert-image-version", ctl.AlertImageVersion, "Version of the Alert Image")
+	cmd.Flags().StringVar(&ctl.CfsslImageName, "cfssl-image-name", ctl.CfsslImageName, "Name of Cfssl Image")
+	cmd.Flags().StringVar(&ctl.CfsslImageVersion, "cfssl-image-version", ctl.CfsslImageVersion, "Version of Cffsl Image")
+	cmd.Flags().StringVar(&ctl.BlackduckHost, "blackduck-host", ctl.BlackduckHost, "Host url of Blackduck")
+	cmd.Flags().StringVar(&ctl.BlackduckUser, "blackduck-user", ctl.BlackduckUser, "Username for Blackduck")
+	cmd.Flags().IntVar(&ctl.BlackduckPort, "blackduck-port", ctl.BlackduckPort, "Port for Blackduck")
+	cmd.Flags().IntVar(&ctl.Port, "port", ctl.Port, "Port for Alert")
+	cmd.Flags().BoolVar(&ctl.StandAlone, "stand-alone", ctl.StandAlone, "Enable Stand Alone mode")
+	cmd.Flags().StringVar(&ctl.AlertMemory, "alert-memory", ctl.AlertMemory, "Memory allocation for the Alert")
+	cmd.Flags().StringVar(&ctl.CfsslMemory, "cfssl-memory", ctl.CfsslMemory, "Memory allocation for the Cfssl")
+	cmd.Flags().StringVar(&ctl.DesiredState, "alert-desired-state", ctl.DesiredState, "State of the Alert")
 
-	assert.Equal(expectedCmd.Flags(), actualCmd.Flags())
+	assert.Equal(cmd.Flags(), actualCmd.Flags())
 }
 
 func TestSetChangedFlags(t *testing.T) {
@@ -145,7 +145,6 @@ func TestSetChangedFlags(t *testing.T) {
 }
 
 func TestSetFlag(t *testing.T) {
-
 	assert := assert.New(t)
 
 	var tests = []struct {

--- a/pkg/blackduck/ctl_blackduck.go
+++ b/pkg/blackduck/ctl_blackduck.go
@@ -114,9 +114,22 @@ func (ctl *Ctl) SetSpec(spec interface{}) error {
 	return nil
 }
 
+func isValidSize(size string) bool {
+	switch size {
+	case
+		"",
+		"small",
+		"medium",
+		"large",
+		"xlarge":
+		return true
+	}
+	return false
+}
+
 // CheckSpecFlags returns an error if a user input was invalid
 func (ctl *Ctl) CheckSpecFlags() error {
-	if ctl.Size != "" && ctl.Size != "small" && ctl.Size != "medium" && ctl.Size != "large" && ctl.Size != "xlarge" {
+	if !isValidSize(ctl.Size) {
 		return fmt.Errorf("Size must be 'small', 'medium', 'large', or 'xlarge'")
 	}
 	for _, pvcJSON := range ctl.PVCJSONSlice {
@@ -235,9 +248,6 @@ func (ctl *Ctl) SetFlag(f *pflag.Flag) {
 			}
 			ctl.Spec.ExternalPostgres.PostgresUserPassword = ctl.ExternalPostgresPostgresUserPassword
 		case "pvc-storage-class":
-			if ctl.Spec.ExternalPostgres == nil {
-				ctl.Spec.ExternalPostgres = &blackduckv1.PostgresExternalDBConfig{}
-			}
 			ctl.Spec.PVCStorageClass = ctl.PvcStorageClass
 		case "liveness-probes":
 			ctl.Spec.LivenessProbes = ctl.LivenessProbes

--- a/pkg/blackduck/ctl_blackduck_test.go
+++ b/pkg/blackduck/ctl_blackduck_test.go
@@ -1,0 +1,483 @@
+/*
+Copyright (C) 2019 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package blackduck
+
+import (
+	"fmt"
+	"testing"
+
+	blackduckv1 "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+	crddefaults "github.com/blackducksoftware/synopsys-operator/pkg/util"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBlackduckCtl(t *testing.T) {
+	assert := assert.New(t)
+	blackduckCtl := NewBlackduckCtl()
+	assert.Equal(&Ctl{
+		Spec:                                  &blackduckv1.BlackduckSpec{},
+		Size:                                  "",
+		DbPrototype:                           "",
+		ExternalPostgresPostgresHost:          "",
+		ExternalPostgresPostgresPort:          0,
+		ExternalPostgresPostgresAdmin:         "",
+		ExternalPostgresPostgresUser:          "",
+		ExternalPostgresPostgresSsl:           false,
+		ExternalPostgresPostgresAdminPassword: "",
+		ExternalPostgresPostgresUserPassword:  "",
+		PvcStorageClass:                       "",
+		LivenessProbes:                        false,
+		ScanType:                              "",
+		PersistentStorage:                     false,
+		PVCJSONSlice:                          []string{},
+		CertificateName:                       "",
+		Certificate:                           "",
+		CertificateKey:                        "",
+		ProxyCertificate:                      "",
+		Type:                                  "",
+		DesiredState:                          "",
+		Environs:                              []string{},
+		ImageRegistries:                       []string{},
+		ImageUIDMapJSONSlice:                  []string{},
+		LicenseKey:                            "",
+	}, blackduckCtl)
+}
+
+func TestGetSpec(t *testing.T) {
+	assert := assert.New(t)
+	blackduckCtl := NewBlackduckCtl()
+	assert.Equal(blackduckv1.BlackduckSpec{}, blackduckCtl.GetSpec())
+}
+
+func TestSetSpec(t *testing.T) {
+	assert := assert.New(t)
+	blackduckCtl := NewBlackduckCtl()
+	specToSet := blackduckv1.BlackduckSpec{Namespace: "test"}
+	blackduckCtl.SetSpec(specToSet)
+	assert.Equal(specToSet, blackduckCtl.GetSpec())
+
+	// check for error
+	assert.EqualError(blackduckCtl.SetSpec(""), "Error setting Blackduck Spec")
+}
+
+func TestCheckSpecFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	// default case
+	blackduckCtl := NewBlackduckCtl()
+	assert.Nil(blackduckCtl.CheckSpecFlags())
+
+	var tests = []struct {
+		input    *Ctl
+		expected string
+	}{
+		// case
+		{input: &Ctl{
+			Spec: &blackduckv1.BlackduckSpec{},
+			Size: "notValid",
+		}, expected: "Size must be 'small', 'medium', 'large', or 'xlarge'"},
+		// case
+		{input: &Ctl{
+			Spec:         &blackduckv1.BlackduckSpec{},
+			PVCJSONSlice: []string{"invalid:"},
+		}, expected: "Invalid format for PVC"},
+		// case
+		{input: &Ctl{
+			Spec:     &blackduckv1.BlackduckSpec{},
+			Environs: []string{"invalid"},
+		}, expected: "Invalid Environ Format - NAME:VALUE"},
+		// case
+		{input: &Ctl{
+			Spec:                 &blackduckv1.BlackduckSpec{},
+			ImageUIDMapJSONSlice: []string{"invalid:"},
+			LicenseKey:           "",
+		}, expected: "Invalid format for Image UID"},
+	}
+
+	for _, test := range tests {
+		assert.EqualError(test.input.CheckSpecFlags(), test.expected)
+	}
+}
+
+func TestSwitchSpec(t *testing.T) {
+	assert := assert.New(t)
+	blackduckCtl := NewBlackduckCtl()
+
+	var tests = []struct {
+		input    string
+		expected *blackduckv1.BlackduckSpec
+	}{
+		{input: "empty", expected: &blackduckv1.BlackduckSpec{}},
+		{input: "persistentStorage", expected: crddefaults.GetHubDefaultPersistentStorage()},
+		{input: "default", expected: crddefaults.GetHubDefaultValue()},
+	}
+
+	// test cases: "empty", "persistentStorage", "default"
+	for _, test := range tests {
+		assert.Nil(blackduckCtl.SwitchSpec(test.input))
+		assert.Equal(*test.expected, blackduckCtl.GetSpec())
+	}
+
+	// test cases: ""
+	createBlackduckSpecType := ""
+	assert.EqualError(blackduckCtl.SwitchSpec(createBlackduckSpecType), fmt.Sprintf("Blackduck Spec Type %s does not match: empty, persistentStorage, default", createBlackduckSpecType))
+
+}
+
+func TestAddSpecFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	ctl := NewBlackduckCtl()
+	actualCmd := &cobra.Command{}
+	ctl.AddSpecFlags(actualCmd)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().StringVar(&ctl.Size, "size", ctl.Size, "size - small, medium, large")
+	cmd.Flags().StringVar(&ctl.DbPrototype, "db-prototype", ctl.DbPrototype, "TODO")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresHost, "external-postgres-host", ctl.ExternalPostgresPostgresHost, "Host for Postgres")
+	cmd.Flags().IntVar(&ctl.ExternalPostgresPostgresPort, "external-postgres-port", ctl.ExternalPostgresPostgresPort, "Port for Postgres")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresAdmin, "external-postgres-admin", ctl.ExternalPostgresPostgresAdmin, "Name of Admin for Postgres")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresUser, "external-postgres-user", ctl.ExternalPostgresPostgresUser, "Username for Postgres")
+	cmd.Flags().BoolVar(&ctl.ExternalPostgresPostgresSsl, "external-postgres-ssl", ctl.ExternalPostgresPostgresSsl, "TODO")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresAdminPassword, "external-postgres-admin-password", ctl.ExternalPostgresPostgresAdminPassword, "Password for the Postgres Admin")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresUserPassword, "external-postgres-user-password", ctl.ExternalPostgresPostgresUserPassword, "Password for a Postgres User")
+	cmd.Flags().StringVar(&ctl.PvcStorageClass, "pvc-storage-class", ctl.PvcStorageClass, "TODO")
+	cmd.Flags().BoolVar(&ctl.LivenessProbes, "liveness-probes", ctl.LivenessProbes, "Enable liveness probes")
+	cmd.Flags().StringVar(&ctl.ScanType, "scan-type", ctl.ScanType, "TODO")
+	cmd.Flags().BoolVar(&ctl.PersistentStorage, "persistent-storage", ctl.PersistentStorage, "Enable persistent storage")
+	cmd.Flags().StringSliceVar(&ctl.PVCJSONSlice, "pvc", ctl.PVCJSONSlice, "List of PVC json structs")
+	cmd.Flags().StringVar(&ctl.CertificateName, "db-certificate-name", ctl.CertificateName, "TODO")
+	cmd.Flags().StringVar(&ctl.Certificate, "certificate", ctl.Certificate, "TODO")
+	cmd.Flags().StringVar(&ctl.CertificateKey, "certificate-key", ctl.CertificateKey, "TODO")
+	cmd.Flags().StringVar(&ctl.ProxyCertificate, "proxy-certificate", ctl.ProxyCertificate, "TODO")
+	cmd.Flags().StringVar(&ctl.Type, "type", ctl.Type, "Type of Blackduck")
+	cmd.Flags().StringVar(&ctl.DesiredState, "desired-state", ctl.DesiredState, "Desired state of Blackduck")
+	cmd.Flags().StringSliceVar(&ctl.Environs, "environs", ctl.Environs, "List of Environment Variables (NAME:VALUE)")
+	cmd.Flags().StringSliceVar(&ctl.ImageRegistries, "image-registries", ctl.ImageRegistries, "List of image registries")
+	cmd.Flags().StringSliceVar(&ctl.ImageUIDMapJSONSlice, "image-uid-map", ctl.ImageUIDMapJSONSlice, "TODO")
+	cmd.Flags().StringVar(&ctl.LicenseKey, "license-key", ctl.LicenseKey, "License Key for the Knowledge Base")
+
+	assert.Equal(cmd.Flags(), actualCmd.Flags())
+}
+
+func TestSetChangedFlags(t *testing.T) {
+	assert := assert.New(t)
+
+	actualCtl := NewBlackduckCtl()
+	cmd := &cobra.Command{}
+	actualCtl.AddSpecFlags(cmd)
+	actualCtl.SetChangedFlags(cmd.Flags())
+
+	expCtl := NewBlackduckCtl()
+
+	assert.Equal(expCtl.Spec, actualCtl.Spec)
+
+}
+
+func TestSetFlag(t *testing.T) {
+	assert := assert.New(t)
+
+	var tests = []struct {
+		flagName    string
+		initialCtl  *Ctl
+		changedCtl  *Ctl
+		changedSpec *blackduckv1.BlackduckSpec
+	}{
+		// case
+		{
+			flagName:   "size",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec: &blackduckv1.BlackduckSpec{},
+				Size: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{Size: "changed"},
+		},
+		// case
+		{
+			flagName:   "db-prototype",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:        &blackduckv1.BlackduckSpec{},
+				DbPrototype: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{DbPrototype: "changed"},
+		},
+		// case
+		{
+			flagName:   "external-postgres-host",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:                         &blackduckv1.BlackduckSpec{},
+				ExternalPostgresPostgresHost: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{
+				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
+					PostgresHost: "changed"}},
+		},
+		// case
+		{
+			flagName:   "external-postgres-port",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:                         &blackduckv1.BlackduckSpec{},
+				ExternalPostgresPostgresPort: 10,
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{
+				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
+					PostgresPort: 10}},
+		},
+		// case
+		{
+			flagName:   "external-postgres-admin",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:                          &blackduckv1.BlackduckSpec{},
+				ExternalPostgresPostgresAdmin: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{
+				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
+					PostgresAdmin: "changed"}},
+		},
+		// case
+		{
+			flagName:   "external-postgres-user",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:                         &blackduckv1.BlackduckSpec{},
+				ExternalPostgresPostgresUser: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{
+				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
+					PostgresUser: "changed"}},
+		},
+		// case
+		{
+			flagName:   "external-postgres-ssl",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:                        &blackduckv1.BlackduckSpec{},
+				ExternalPostgresPostgresSsl: true,
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{
+				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
+					PostgresSsl: true}},
+		},
+		// case
+		{
+			flagName:   "external-postgres-admin-password",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:                                  &blackduckv1.BlackduckSpec{},
+				ExternalPostgresPostgresAdminPassword: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{
+				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
+					PostgresAdminPassword: "changed"}},
+		},
+		// case
+		{
+			flagName:   "external-postgres-user-password",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:                                 &blackduckv1.BlackduckSpec{},
+				ExternalPostgresPostgresUserPassword: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{
+				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
+					PostgresUserPassword: "changed"}},
+		},
+		// case
+		{
+			flagName:   "pvc-storage-class",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:            &blackduckv1.BlackduckSpec{},
+				PvcStorageClass: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{PVCStorageClass: "changed"},
+		},
+		// case
+		{
+			flagName:   "liveness-probes",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:           &blackduckv1.BlackduckSpec{},
+				LivenessProbes: true,
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{LivenessProbes: true},
+		},
+		// case
+		{
+			flagName:   "scan-type",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:     &blackduckv1.BlackduckSpec{},
+				ScanType: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{ScanType: "changed"},
+		},
+		// case
+		{
+			flagName:   "persistent-storage",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:              &blackduckv1.BlackduckSpec{},
+				PersistentStorage: true,
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{PersistentStorage: true},
+		},
+		// case
+		{
+			flagName:   "pvc",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:         &blackduckv1.BlackduckSpec{},
+				PVCJSONSlice: []string{"{\"name\": \"changed\", \"size\": \"1G\"}"},
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{PVC: []blackduckv1.PVC{{Name: "changed", Size: "1G"}}},
+		},
+		// case
+		{
+			flagName:   "db-certificate-name",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:            &blackduckv1.BlackduckSpec{},
+				CertificateName: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{CertificateName: "changed"},
+		},
+		// case
+		{
+			flagName:   "certificate",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:        &blackduckv1.BlackduckSpec{},
+				Certificate: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{Certificate: "changed"},
+		},
+		// case
+		{
+			flagName:   "certificate-key",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:           &blackduckv1.BlackduckSpec{},
+				CertificateKey: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{CertificateKey: "changed"},
+		},
+		// case
+		{
+			flagName:   "proxy-certificate",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:             &blackduckv1.BlackduckSpec{},
+				ProxyCertificate: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{ProxyCertificate: "changed"},
+		},
+		// case
+		{
+			flagName:   "type",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec: &blackduckv1.BlackduckSpec{},
+				Type: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{Type: "changed"},
+		},
+		// case
+		{
+			flagName:   "desired-state",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:         &blackduckv1.BlackduckSpec{},
+				DesiredState: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{DesiredState: "changed"},
+		},
+		// case
+		{
+			// TODO: add a check in environs for correct input string format
+			flagName:   "environs",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:     &blackduckv1.BlackduckSpec{},
+				Environs: []string{"changed"},
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{Environs: []string{"changed"}},
+		},
+		// case
+		{
+			// TODO: add a check for name:Val
+			flagName:   "image-registries",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:            &blackduckv1.BlackduckSpec{},
+				ImageRegistries: []string{"changed"},
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{ImageRegistries: []string{"changed"}},
+		},
+		// case
+		{
+			flagName:   "image-uid-map",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:                 &blackduckv1.BlackduckSpec{},
+				ImageUIDMapJSONSlice: []string{"{\"Key\": \"changed\", \"Value\": 1}"},
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{ImageUIDMap: map[string]int64{"changed": 1}},
+		},
+		// case
+		{
+			flagName:   "license-key",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec:       &blackduckv1.BlackduckSpec{},
+				LicenseKey: "changed",
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{LicenseKey: "changed"},
+		},
+		// case
+		{
+			flagName:   "",
+			initialCtl: NewBlackduckCtl(),
+			changedCtl: &Ctl{
+				Spec: &blackduckv1.BlackduckSpec{},
+			},
+			changedSpec: &blackduckv1.BlackduckSpec{},
+		},
+	}
+
+	for _, test := range tests {
+		actualCtl := NewBlackduckCtl()
+		assert.Equal(test.initialCtl, actualCtl)
+		actualCtl = test.changedCtl
+		f := &pflag.Flag{Changed: true, Name: test.flagName}
+		actualCtl.SetFlag(f)
+		assert.Equal(test.changedSpec, actualCtl.Spec)
+	}
+
+}


### PR DESCRIPTION
- [x] Adds test for `ctl_blackduck` (`/pkg/blackduck` now has 17.8% code coverage)
- [x] Fixes few things in `ctl_blackduck`
- [x] Refactors parts of `ctl_alert_test`