### PR TITLE
Remove PVCs from list instead of adding them

### DIFF
--- a/pkg/apps/blackduck/latest/containers/pvc.go
+++ b/pkg/apps/blackduck/latest/containers/pvc.go
@@ -51,8 +51,8 @@ func (c *Creater) GetPVCs() []*components.PersistentVolumeClaim {
 	if c.hubSpec.ExternalPostgres != nil {
 		delete(defaultPVC, "blackduck-postgres")
 	}
-	if c.isBinaryAnalysisEnabled {
-		defaultPVC["blackduck-rabbitmq"] = "5Gi"
+	if !c.isBinaryAnalysisEnabled {
+		delete(defaultPVC, "blackduck-rabbitmq")
 	}
 
 	if c.hubSpec.PersistentStorage {

--- a/pkg/apps/blackduck/v1/containers/pvc.go
+++ b/pkg/apps/blackduck/v1/containers/pvc.go
@@ -43,15 +43,18 @@ func (c *Creater) GetPVCs() []*components.PersistentVolumeClaim {
 		"blackduck-logstash":          "20Gi",
 		"blackduck-zookeeper-data":    "2Gi",
 		"blackduck-zookeeper-datalog": "2Gi",
+		"blackduck-rabbitmq":          "5Gi",
+		"blackduck-uploadcache-data":  "100Gi",
+		"blackduck-uploadcache-key":   "2Gi",
 	}
 
 	if c.hubSpec.ExternalPostgres != nil {
 		delete(defaultPVC, "blackduck-postgres")
 	}
-	if c.isBinaryAnalysisEnabled {
-		defaultPVC["blackduck-rabbitmq"] = "5Gi"
-		defaultPVC["blackduck-uploadcache-data"] = "100Gi"
-		defaultPVC["blackduck-uploadcache-key"] = "2Gi"
+	if !c.isBinaryAnalysisEnabled {
+		delete(defaultPVC, "blackduck-rabbitmq")
+		delete(defaultPVC, "blackduck-uploadcache-data")
+		delete(defaultPVC, "blackduck-uploadcache-key")
 	}
 
 	if c.hubSpec.PersistentStorage {


### PR DESCRIPTION
Keep the PVC names all together in the map, then remove the ones that are not needed. 