### PR TITLE
change alert's cfssl service to be default instead of nodeport

### DIFF
--- a/pkg/apps/alert/latest/cfsslservice.go
+++ b/pkg/apps/alert/latest/cfsslservice.go
@@ -31,7 +31,7 @@ func (a *SpecConfig) getCfsslService() *components.Service {
 	service := components.NewService(horizonapi.ServiceConfig{
 		Name:          "cfssl",
 		Namespace:     a.config.Namespace,
-		IPServiceType: horizonapi.ClusterIPServiceTypeNodePort,
+		IPServiceType: horizonapi.ClusterIPServiceTypeDefault,
 	})
 
 	service.AddPort(horizonapi.ServicePortConfig{


### PR DESCRIPTION
We don't cfssl to be exposed.