### PR TITLE
remove non-versioned kubernetes.Clientset calls and add versioned calls in scope of #214

### DIFF
--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -941,22 +941,22 @@ func IsClusterRoleBindingSubjectExist(subjects []rbacv1.Subject, namespace strin
 
 // GetClusterRole get a cluster role
 func GetClusterRole(clientset *kubernetes.Clientset, name string) (*rbacv1.ClusterRole, error) {
-	return clientset.Rbac().ClusterRoles().Get(name, metav1.GetOptions{})
+	return clientset.RbacV1().ClusterRoles().Get(name, metav1.GetOptions{})
 }
 
 // ListClusterRoles list a cluster role
 func ListClusterRoles(clientset *kubernetes.Clientset, labelSelector string) (*rbacv1.ClusterRoleList, error) {
-	return clientset.Rbac().ClusterRoles().List(metav1.ListOptions{LabelSelector: labelSelector})
+	return clientset.RbacV1().ClusterRoles().List(metav1.ListOptions{LabelSelector: labelSelector})
 }
 
 // UpdateClusterRole updates the cluster role
 func UpdateClusterRole(clientset *kubernetes.Clientset, clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
-	return clientset.Rbac().ClusterRoles().Update(clusterRole)
+	return clientset.RbacV1().ClusterRoles().Update(clusterRole)
 }
 
 // DeleteClusterRole delete a cluster role binding
 func DeleteClusterRole(clientset *kubernetes.Clientset, name string) error {
-	return clientset.Rbac().ClusterRoles().Delete(name, &metav1.DeleteOptions{})
+	return clientset.RbacV1().ClusterRoles().Delete(name, &metav1.DeleteOptions{})
 }
 
 // IsClusterRoleRuleExist checks whether the namespace is already exist in the rule of cluster role

--- a/pkg/util/controller.go
+++ b/pkg/util/controller.go
@@ -44,7 +44,7 @@ func NewPodListController(ns string) *PodListController {
 func (l *PodListController) Run(resources horizonapi.ControllerResources, stopCh chan struct{}) error {
 	client := resources.KubeClient
 	for cnt := 0; cnt < 20; cnt++ {
-		pods, _ := client.Core().Pods(l.namespace).List(v1meta.ListOptions{})
+		pods, _ := client.CoreV1().Pods(l.namespace).List(v1meta.ListOptions{})
 		var isPodNotRunning bool
 		for _, pod := range pods.Items {
 			log.Debugf("Pod = %v -> %v", pod.Name, pod.Status.Phase)


### PR DESCRIPTION
Fix #214.

At least changed it for the ones I found, let me know if you know of other places we use non-versioned ones.

- [ ] change it in upstream vendor repos we're using, I saw some deprecated calls in `horizon` 