### PR TITLE
OpenShift route and CRUD updater

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -23,7 +23,19 @@ package api
 
 import (
 	"github.com/blackducksoftware/horizon/pkg/components"
+	routev1 "github.com/openshift/api/route/v1"
 )
+
+// Route defines the route component
+type Route struct {
+	Namespace          string
+	Name               string
+	Kind               string
+	ServiceName        string
+	PortName           string
+	Labels             map[string]string
+	TLSTerminationType routev1.TLSTerminationType
+}
 
 // ComponentList defines the list of components for an app
 type ComponentList struct {
@@ -36,4 +48,5 @@ type ComponentList struct {
 	Deployments            []*components.Deployment
 	Secrets                []*components.Secret
 	PersistentVolumeClaims []*components.PersistentVolumeClaim
+	Routes                 []*Route
 }

--- a/pkg/apps/alert/alert.go
+++ b/pkg/apps/alert/alert.go
@@ -63,11 +63,6 @@ func NewAlert(config *protoform.Config, kubeConfig *rest.Config) *Alert {
 	routeClient, err := routeclient.NewForConfig(kubeConfig)
 	if err != nil {
 		routeClient = nil
-	} else {
-		_, err := util.GetOpenShiftRoutes(routeClient, "default", "docker-registry")
-		if err != nil {
-			routeClient = nil
-		}
 	}
 	// Initialize creaters for different versions of Alert (each Creater can support differernt versions)
 	creaters := []Creater{

--- a/pkg/apps/alert/latest/alert_components.go
+++ b/pkg/apps/alert/latest/alert_components.go
@@ -92,5 +92,11 @@ func (a *SpecConfig) GetComponents() (*api.ComponentList, error) {
 		components.Services = append(components.Services, a.getCfsslService())
 	}
 
+	// Add routes for OpenShift
+	route := a.GetOpenShiftRoute()
+	if route != nil {
+		components.Routes = []*api.Route{route}
+	}
+
 	return components, nil
 }

--- a/pkg/apps/alert/latest/alert_creater.go
+++ b/pkg/apps/alert/latest/alert_creater.go
@@ -28,10 +28,7 @@ import (
 	alertapi "github.com/blackducksoftware/synopsys-operator/pkg/api/alert/v1"
 	"github.com/blackducksoftware/synopsys-operator/pkg/crdupdater"
 	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
-	"github.com/blackducksoftware/synopsys-operator/pkg/util"
-	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -68,15 +65,6 @@ func (ac *Creater) Ensure(alert *alertapi.Alert) error {
 	_, errors := commonConfig.CRUDComponents()
 	if len(errors) > 0 {
 		return fmt.Errorf("unable to update Alert components due to %+v", errors)
-	}
-
-	// Create Route if on Openshift
-	if ac.RouteClient != nil && alert.Spec.ExposeService == "OPENSHIFT" {
-		log.Debugf("creating an Openshift Route for Alert")
-		_, err := util.CreateOpenShiftRoutes(ac.RouteClient, alert.Spec.Namespace, alert.Spec.Namespace, "Service", "alert", fmt.Sprintf("%d-tcp", *specConfig.config.Port), routev1.TLSTerminationPassthrough)
-		if err != nil {
-			log.Errorf("unable to create the openshift route due to %+v", err)
-		}
 	}
 	return nil
 }

--- a/pkg/apps/alert/latest/route.go
+++ b/pkg/apps/alert/latest/route.go
@@ -1,0 +1,47 @@
+/*
+Copyright (C) 2019 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package alert
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
+	"github.com/blackducksoftware/synopsys-operator/pkg/util"
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+// GetOpenShiftRoute creates the OpenShift route component for the alert
+func (a *SpecConfig) GetOpenShiftRoute() *api.Route {
+	if strings.ToUpper(a.config.ExposeService) == util.OPENSHIFT {
+		return &api.Route{
+			Name:               a.config.Namespace,
+			Namespace:          a.config.Namespace,
+			Kind:               "Service",
+			ServiceName:        "alert",
+			PortName:           fmt.Sprintf("%d-tcp", *a.config.Port),
+			Labels:             map[string]string{"app": "alert"},
+			TLSTerminationType: routev1.TLSTerminationPassthrough,
+		}
+	}
+	return nil
+}

--- a/pkg/apps/blackduck/latest/containers/route.go
+++ b/pkg/apps/blackduck/latest/containers/route.go
@@ -1,0 +1,46 @@
+/*
+Copyright (C) 2019 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package containers
+
+import (
+	"strings"
+
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
+	"github.com/blackducksoftware/synopsys-operator/pkg/util"
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+// GetOpenShiftRoute creates the OpenShift route component for the webserver
+func (c *Creater) GetOpenShiftRoute() *api.Route {
+	if strings.ToUpper(c.hubSpec.ExposeService) == util.OPENSHIFT {
+		return &api.Route{
+			Name:               c.hubSpec.Namespace,
+			Namespace:          c.hubSpec.Namespace,
+			Kind:               "Service",
+			ServiceName:        "webserver",
+			PortName:           "port-webserver",
+			Labels:             map[string]string{"app": "blackduck", "component": "webserver"},
+			TLSTerminationType: routev1.TLSTerminationPassthrough,
+		}
+	}
+	return nil
+}

--- a/pkg/apps/blackduck/latest/creater.go
+++ b/pkg/apps/blackduck/latest/creater.go
@@ -25,7 +25,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"math"
 	"net/http"
 	"reflect"
@@ -41,9 +40,9 @@ import (
 	"github.com/blackducksoftware/synopsys-operator/pkg/crdupdater"
 	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
-	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -170,14 +169,8 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// Create Route on Openshift
-		if strings.ToUpper(blackduck.Spec.ExposeService) == "OPENSHIFT" && hc.routeClient != nil {
-			route, err := util.GetOpenShiftRoutes(hc.routeClient, blackduck.Spec.Namespace, blackduck.Spec.Namespace)
-			if err != nil {
-				route, err = util.CreateOpenShiftRoutes(hc.routeClient, blackduck.Spec.Namespace, blackduck.Spec.Namespace, "Service", "webserver", "port-webserver", routev1.TLSTerminationPassthrough)
-				if err != nil {
-					log.Errorf("unable to create the openshift route due to %+v", err)
-				}
-			}
+		if strings.ToUpper(blackduck.Spec.ExposeService) == util.OPENSHIFT && hc.routeClient != nil {
+			route, _ := util.GetRoute(hc.routeClient, blackduck.Spec.Namespace, blackduck.Spec.Namespace)
 			if route != nil {
 				newBlackuck.Status.IP = route.Spec.Host
 			}

--- a/pkg/apps/blackduck/latest/deployer.go
+++ b/pkg/apps/blackduck/latest/deployer.go
@@ -197,6 +197,12 @@ func (hc *Creater) getComponents(blackduck *blackduckapi.Blackduck) (*api.Compon
 	if svc := hc.getExposeService(blackduck); svc != nil {
 		componentList.Services = append(componentList.Services, svc)
 	}
+
+	// Add OpenShift routes
+	route := containerCreater.GetOpenShiftRoute()
+	if route != nil {
+		componentList.Routes = []*api.Route{route}
+	}
 	return componentList, nil
 }
 

--- a/pkg/apps/blackduck/v1/containers/route.go
+++ b/pkg/apps/blackduck/v1/containers/route.go
@@ -1,0 +1,46 @@
+/*
+Copyright (C) 2019 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package containers
+
+import (
+	"strings"
+
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
+	"github.com/blackducksoftware/synopsys-operator/pkg/util"
+	routev1 "github.com/openshift/api/route/v1"
+)
+
+// GetOpenShiftRoute creates the OpenShift route component for the webserver
+func (c *Creater) GetOpenShiftRoute() *api.Route {
+	if strings.ToUpper(c.hubSpec.ExposeService) == util.OPENSHIFT {
+		return &api.Route{
+			Name:               c.hubSpec.Namespace,
+			Namespace:          c.hubSpec.Namespace,
+			Kind:               "Service",
+			ServiceName:        "webserver",
+			PortName:           "port-webserver",
+			Labels:             map[string]string{"app": "blackduck", "component": "webserver"},
+			TLSTerminationType: routev1.TLSTerminationPassthrough,
+		}
+	}
+	return nil
+}

--- a/pkg/apps/blackduck/v1/creater.go
+++ b/pkg/apps/blackduck/v1/creater.go
@@ -41,7 +41,6 @@ import (
 	"github.com/blackducksoftware/synopsys-operator/pkg/crdupdater"
 	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
-	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	log "github.com/sirupsen/logrus"
@@ -162,14 +161,8 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// Create Route on Openshift
-		if strings.ToUpper(blackduck.Spec.ExposeService) == "OPENSHIFT" && hc.routeClient != nil {
-			route, err := util.GetOpenShiftRoutes(hc.routeClient, blackduck.Spec.Namespace, blackduck.Spec.Namespace)
-			if err != nil {
-				route, err = util.CreateOpenShiftRoutes(hc.routeClient, blackduck.Spec.Namespace, blackduck.Spec.Namespace, "Service", "webserver", "port-webserver", routev1.TLSTerminationPassthrough)
-				if err != nil {
-					log.Errorf("unable to create the openshift route due to %+v", err)
-				}
-			}
+		if strings.ToUpper(blackduck.Spec.ExposeService) == util.OPENSHIFT && hc.routeClient != nil {
+			route, _ := util.GetRoute(hc.routeClient, blackduck.Spec.Namespace, blackduck.Spec.Namespace)
 			if route != nil {
 				newBlackuck.Status.IP = route.Spec.Host
 			}

--- a/pkg/apps/blackduck/v1/deployer.go
+++ b/pkg/apps/blackduck/v1/deployer.go
@@ -194,6 +194,12 @@ func (hc *Creater) getComponents(blackduck *blackduckapi.Blackduck) (*api.Compon
 	if svc := hc.getExposeService(blackduck); svc != nil {
 		componentList.Services = append(componentList.Services, svc)
 	}
+
+	// Add OpenShift routes
+	route := containerCreater.GetOpenShiftRoute()
+	if route != nil {
+		componentList.Routes = []*api.Route{route}
+	}
 	return componentList, nil
 }
 

--- a/pkg/blackduck/util/helpers.go
+++ b/pkg/blackduck/util/helpers.go
@@ -71,8 +71,6 @@ func GetLoadBalancerIPAddress(kubeClient *kubernetes.Clientset, namespace string
 		return "", fmt.Errorf("unable to get service %s in %s namespace because %s", serviceName, namespace, err.Error())
 	}
 
-	log.Debugf("[%s] service: %v", serviceName, service.Status.LoadBalancer.Ingress)
-
 	if len(service.Status.LoadBalancer.Ingress) > 0 {
 		ipAddress := service.Status.LoadBalancer.Ingress[0].IP
 		return ipAddress, nil
@@ -92,7 +90,6 @@ func GetNodePortIPAddress(kubeClient *kubernetes.Clientset, namespace string, se
 	var nodePort []int32
 	// Get the nodeport
 	for _, port := range service.Spec.Ports {
-		log.Debugf("[%s] node port: %v", namespace, port.NodePort)
 		nodePort = append(nodePort, port.NodePort)
 	}
 	return intArrayToStringArray(nodePort, ","), nil

--- a/pkg/crdupdater/crudcomponents.go
+++ b/pkg/crdupdater/crudcomponents.go
@@ -75,71 +75,89 @@ func (c *CommonConfig) CRUDComponents() (bool, []error) {
 	namespaces, err := NewNamespace(c)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new namespace updater due to %+v", err))
+	} else {
+		updater.AddUpdater(namespaces)
 	}
-	updater.AddUpdater(namespaces)
 
 	// service account
 	serviceAccounts, err := NewServiceAccount(c, c.components.ServiceAccounts)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new service account updater due to %+v", err))
+	} else {
+		updater.AddUpdater(serviceAccounts)
 	}
-	updater.AddUpdater(serviceAccounts)
 
 	// cluster role
 	clusterRoles, err := NewClusterRole(c, c.components.ClusterRoles)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new cluster role updater due to %+v", err))
+	} else {
+		updater.AddUpdater(clusterRoles)
 	}
-	updater.AddUpdater(clusterRoles)
 
 	// cluster role binding
 	clusterRoleBindings, err := NewClusterRoleBinding(c, c.components.ClusterRoleBindings)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new cluster role binding updater due to %+v", err))
+	} else {
+		updater.AddUpdater(clusterRoleBindings)
 	}
-	updater.AddUpdater(clusterRoleBindings)
 
 	// config map
 	configMaps, err := NewConfigMap(c, c.components.ConfigMaps)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new config map updater due to %+v", err))
+	} else {
+		updater.AddUpdater(configMaps)
 	}
-	updater.AddUpdater(configMaps)
 
 	// secret
 	secrets, err := NewSecret(c, c.components.Secrets)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new secret updater due to %+v", err))
+	} else {
+		updater.AddUpdater(secrets)
 	}
-	updater.AddUpdater(secrets)
 
 	// persistent volume claim
 	pvcs, err := NewPersistentVolumeClaim(c, c.components.PersistentVolumeClaims)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new persistent volume claim updater due to %+v", err))
+	} else {
+		updater.AddUpdater(pvcs)
 	}
-	updater.AddUpdater(pvcs)
 
 	// service
 	services, err := NewService(c, c.components.Services)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new service updater due to %+v", err))
+	} else {
+		updater.AddUpdater(services)
 	}
-	updater.AddUpdater(services)
 
 	// replication controller
 	rcs, err := NewReplicationController(c, c.components.ReplicationControllers)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new replication controller updater due to %+v", err))
+	} else {
+		updater.AddUpdater(rcs)
 	}
-	updater.AddUpdater(rcs)
 
 	// deployment
 	deployments, err := NewDeployment(c, c.components.Deployments)
 	if err != nil {
 		errors = append(errors, fmt.Errorf("unable to create new deployment updater due to %+v", err))
+	} else {
+		updater.AddUpdater(deployments)
 	}
-	updater.AddUpdater(deployments)
+
+	// OpenShift routes
+	routes, err := NewRoute(c, c.components.Routes)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("unable to create route updater due to %+v", err))
+	} else {
+		updater.AddUpdater(routes)
+	}
 
 	// execute updates for all added components
 	isPatched, err := updater.Update()

--- a/pkg/crdupdater/helpers.go
+++ b/pkg/crdupdater/helpers.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type label struct {
@@ -117,6 +119,39 @@ func isLabelsExist(expectedLabels map[string]label, actualLabels map[string]stri
 		}
 	}
 	return true
+}
+
+type servicePort struct {
+	Name       string             `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	Protocol   corev1.Protocol    `json:"protocol,omitempty" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
+	Port       int32              `json:"port" protobuf:"varint,3,opt,name=port"`
+	TargetPort intstr.IntOrString `json:"targetPort,omitempty" protobuf:"bytes,4,opt,name=targetPort"`
+}
+
+func sortPorts(ports []corev1.ServicePort) []servicePort {
+	sort.Slice(ports, func(i, j int) bool { return ports[i].Name < ports[j].Name })
+	servicePorts := []servicePort{}
+	for _, port := range ports {
+		servicePorts = append(servicePorts, servicePort{Name: port.Name, Protocol: port.Protocol, Port: port.Port, TargetPort: port.TargetPort})
+	}
+	return servicePorts
+}
+
+type policyRule struct {
+	Verbs     []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
+	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,2,rep,name=apiGroups"`
+	Resources []string `json:"resources,omitempty" protobuf:"bytes,3,rep,name=resources"`
+}
+
+func sortPolicyRule(rules []rbacv1.PolicyRule) []policyRule {
+	policyRules := []policyRule{}
+	for _, rule := range rules {
+		sort.Strings(rule.APIGroups)
+		sort.Strings(rule.Resources)
+		sort.Strings(rule.Verbs)
+		policyRules = append(policyRules, policyRule{Verbs: rule.Verbs, APIGroups: rule.APIGroups, Resources: rule.APIGroups})
+	}
+	return policyRules
 }
 
 func sortEnvs(envs []corev1.EnvVar) []corev1.EnvVar {

--- a/pkg/crdupdater/route.go
+++ b/pkg/crdupdater/route.go
@@ -1,0 +1,138 @@
+/*
+Copyright (C) 2019 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package crdupdater
+
+import (
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
+	"github.com/blackducksoftware/synopsys-operator/pkg/util"
+	"github.com/juju/errors"
+	routev1 "github.com/openshift/api/route/v1"
+	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	log "github.com/sirupsen/logrus"
+)
+
+// Route stores the configuration to add or delete the route
+type Route struct {
+	config      *CommonConfig
+	deployer    *util.DeployerHelper
+	routeClient *routeclient.RouteV1Client
+	routes      []*api.Route
+	oldRoutes   map[string]routev1.Route
+	newRoutes   map[string]*routev1.Route
+}
+
+// NewRoute returns the route configuration
+func NewRoute(config *CommonConfig, routes []*api.Route) (*Route, error) {
+	deployer, err := util.NewDeployer(config.kubeConfig)
+	if err != nil {
+		return nil, errors.Annotatef(err, "unable to get deployer object for %s", config.namespace)
+	}
+	newRoutes := append([]*api.Route{}, routes...)
+	for i := 0; i < len(newRoutes); i++ {
+		if !isLabelsExist(config.expectedLabels, newRoutes[i].Labels) {
+			newRoutes = append(newRoutes[:i], newRoutes[i+1:]...)
+			i--
+		}
+	}
+	routeClient, err := routeclient.NewForConfig(config.kubeConfig)
+	if err != nil {
+		log.Errorf("unable to create the route client due to %+v", err)
+		return nil, errors.Annotatef(err, "unable to create the route client for %s", config.namespace)
+	}
+	return &Route{
+		config:      config,
+		deployer:    deployer,
+		routeClient: routeClient,
+		routes:      newRoutes,
+		oldRoutes:   make(map[string]routev1.Route, 0),
+		newRoutes:   make(map[string]*routev1.Route, 0),
+	}, nil
+}
+
+// buildNewAndOldObject builds the old and new route
+func (c *Route) buildNewAndOldObject() error {
+	// build old route
+	oldRoutes, err := c.list()
+	if err != nil {
+		return errors.Annotatef(err, "unable to get routes for %s", c.config.namespace)
+	}
+
+	for _, oldRoute := range oldRoutes.(*routev1.RouteList).Items {
+		c.oldRoutes[oldRoute.GetName()] = oldRoute
+	}
+
+	// build new route
+	for i, newRoute := range c.routes {
+		newRouteKube := util.GetRouteComponent(c.routeClient, newRoute, c.routes[i].Labels)
+		c.newRoutes[newRoute.Name] = newRouteKube
+	}
+
+	return nil
+}
+
+// add adds the route
+func (c *Route) add(isPatched bool) (bool, error) {
+	for _, route := range c.routes {
+		if _, ok := c.oldRoutes[route.Name]; !ok && !c.config.dryRun {
+			_, err := util.CreateRoute(c.routeClient, c.config.namespace, c.newRoutes[route.Name])
+			if err != nil {
+				return false, errors.Annotatef(err, "unable to deploy route in %s", c.config.namespace)
+			}
+		}
+	}
+	return false, nil
+}
+
+// get gets the route
+func (c *Route) get(name string) (interface{}, error) {
+	return util.GetRoute(c.routeClient, c.config.namespace, name)
+}
+
+// list lists all the routes
+func (c *Route) list() (interface{}, error) {
+	return util.ListRoutes(c.routeClient, c.config.namespace, c.config.labelSelector)
+}
+
+// delete deletes the route
+func (c *Route) delete(name string) error {
+	log.Infof("deleting the route: %s", name)
+	return util.DeleteRoute(c.routeClient, c.config.namespace, name)
+}
+
+// remove removes the route
+func (c *Route) remove() error {
+	// compare the old and new route and delete if needed
+	for _, oldRoute := range c.oldRoutes {
+		if _, ok := c.newRoutes[oldRoute.GetName()]; !ok {
+			err := c.delete(oldRoute.GetName())
+			if err != nil {
+				return errors.Annotatef(err, "unable to delete route %s in namespace %s", oldRoute.GetName(), c.config.namespace)
+			}
+		}
+	}
+	return nil
+}
+
+// patch patches the route
+func (c *Route) patch(cr interface{}, isPatched bool) (bool, error) {
+	return false, nil
+}

--- a/pkg/opssight/creater.go
+++ b/pkg/opssight/creater.go
@@ -23,7 +23,6 @@ package opssight
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -35,7 +34,6 @@ import (
 	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	"github.com/juju/errors"
-	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	log "github.com/sirupsen/logrus"
@@ -43,11 +41,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-)
-
-const (
-	// OPENSHIFT will denote to create openshift route
-	OPENSHIFT = "OPENSHIFT"
 )
 
 // Creater will store the configuration to create OpsSight
@@ -253,25 +246,36 @@ func (ac *Creater) addRegistryAuth(opsSightSpec *opssightapi.OpsSightSpec) {
 	}
 
 	internalRegistries := []*string{}
-	route, err := util.GetOpenShiftRoutes(ac.routeClient, "default", "docker-registry")
-	if err != nil {
-		log.Errorf("unable to get docker-registry router in default namespace due to %+v", err)
-	} else {
-		internalRegistries = append(internalRegistries, &route.Spec.Host)
-		routeHostPort := fmt.Sprintf("%s:443", route.Spec.Host)
-		internalRegistries = append(internalRegistries, &routeHostPort)
+
+	// Adding default image registry routes
+	routes := map[string]string{"default": "docker-registry", "openshift-image-registry": "image-registry"}
+	for namespace, name := range routes {
+		route, err := util.GetRoute(ac.routeClient, namespace, name)
+		if err != nil {
+			log.Warnf("unable to find an OpenShift %s router in %s namespace due to %+v", name, namespace, err)
+		} else {
+			internalRegistries = append(internalRegistries, &route.Spec.Host)
+			routeHostPort := fmt.Sprintf("%s:443", route.Spec.Host)
+			internalRegistries = append(internalRegistries, &routeHostPort)
+		}
 	}
 
-	registrySvc, err := util.GetService(ac.kubeClient, "default", "docker-registry")
-	if err != nil {
-		log.Errorf("unable to get docker-registry service in default namespace due to %+v", err)
-	} else {
-		if !strings.EqualFold(registrySvc.Spec.ClusterIP, "") {
-			for _, port := range registrySvc.Spec.Ports {
-				clusterIPSvc := fmt.Sprintf("%s:%s", registrySvc.Spec.ClusterIP, strconv.Itoa(int(port.Port)))
-				internalRegistries = append(internalRegistries, &clusterIPSvc)
-				clusterIPSvcPort := fmt.Sprintf("%s:%s", "docker-registry.default.svc", strconv.Itoa(int(port.Port)))
-				internalRegistries = append(internalRegistries, &clusterIPSvcPort)
+	// Adding default OpenShift internal Docker/image registry service
+	labelSelectors := []string{"docker-registry=default", "router in (router,router-default)"}
+	for _, labelSelector := range labelSelectors {
+		registrySvcs, err := util.ListServices(ac.kubeClient, "", labelSelector)
+		if err != nil {
+			log.Warnf("unable to find an OpenShift image registry service with labels %s due to %+v", labelSelector, err)
+			continue
+		}
+		for _, registrySvc := range registrySvcs.Items {
+			if !strings.EqualFold(registrySvc.Spec.ClusterIP, "") {
+				for _, port := range registrySvc.Spec.Ports {
+					clusterIPSvc := fmt.Sprintf("%s:%d", registrySvc.Spec.ClusterIP, port.Port)
+					internalRegistries = append(internalRegistries, &clusterIPSvc)
+					clusterIPSvcPort := fmt.Sprintf("%s.%s.svc:%d", registrySvc.Name, registrySvc.Namespace, port.Port)
+					internalRegistries = append(internalRegistries, &clusterIPSvcPort)
+				}
 			}
 		}
 	}
@@ -287,32 +291,6 @@ func (ac *Creater) addRegistryAuth(opsSightSpec *opssightapi.OpsSightSpec) {
 }
 
 func (ac *Creater) postDeploy(spec *SpecConfig, namespace string) error {
-	// Create Perceptor model Route on Openshift
-	if strings.ToUpper(spec.opssight.Spec.Perceptor.Expose) == OPENSHIFT && ac.routeClient != nil {
-		namespace := spec.opssight.Spec.Namespace
-		name := fmt.Sprintf("%s-%s", spec.opssight.Spec.Perceptor.Name, namespace)
-		_, err := util.GetOpenShiftRoutes(ac.routeClient, namespace, name)
-		if err != nil {
-			_, err = util.CreateOpenShiftRoutes(ac.routeClient, namespace, name, "Service", spec.opssight.Spec.Perceptor.Name, fmt.Sprintf("port-%s", spec.opssight.Spec.Perceptor.Name), routev1.TLSTerminationEdge)
-			if err != nil {
-				log.Errorf("unable to create the perceptor openshift route due to %+v", err)
-			}
-		}
-	}
-
-	// Create Perceptor metrics Route on Openshift
-	if strings.ToUpper(spec.opssight.Spec.Prometheus.Expose) == OPENSHIFT && ac.routeClient != nil {
-		namespace := spec.opssight.Spec.Namespace
-		name := fmt.Sprintf("%s-%s", spec.opssight.Spec.Prometheus.Name, namespace)
-		_, err := util.GetOpenShiftRoutes(ac.routeClient, namespace, name)
-		if err != nil {
-			_, err = util.CreateOpenShiftRoutes(ac.routeClient, namespace, name, "Service", spec.opssight.Spec.Prometheus.Name, fmt.Sprintf("port-%s", spec.opssight.Spec.Prometheus.Name), routev1.TLSTerminationEdge)
-			if err != nil {
-				log.Errorf("unable to create the perceptor metrics openshift route due to %+v", err)
-			}
-		}
-	}
-
 	// Need to add the perceptor-scanner service account to the privileged scc
 	if ac.osSecurityClient != nil {
 		scannerServiceAccount := spec.ScannerServiceAccount()

--- a/pkg/opssight/prometheus.go
+++ b/pkg/opssight/prometheus.go
@@ -24,10 +24,14 @@ package opssight
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	"github.com/blackducksoftware/horizon/pkg/components"
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
+	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	"github.com/juju/errors"
+	routev1 "github.com/openshift/api/route/v1"
 )
 
 // PerceptorMetricsDeployment creates a deployment for perceptor metrics
@@ -99,6 +103,7 @@ func (p *SpecConfig) perceptorMetricsVolumes() ([]*components.Volume, error) {
 	vols = append(vols, components.NewConfigMapVolume(horizonapi.ConfigMapOrSecretVolumeConfig{
 		VolumeName:      "prometheus",
 		MapOrSecretName: "prometheus",
+		DefaultMode:     util.IntToInt32(420),
 	}))
 
 	vol, err := components.NewEmptyDirVolume(horizonapi.EmptyDirVolumeConfig{
@@ -244,8 +249,25 @@ func (p *SpecConfig) PerceptorMetricsConfigMap() (*components.ConfigMap, error) 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	configMap.AddLabels(map[string]string{"name": "prometheus", "app": "opssight"})
+	configMap.AddLabels(map[string]string{"app": "opssight"})
 	configMap.AddData(map[string]string{"prometheus.yml": string(bytes)})
 
 	return configMap, nil
+}
+
+// GetPrometheusOpenShiftRoute creates the OpenShift route component for the prometheus metrics
+func (p *SpecConfig) GetPrometheusOpenShiftRoute() *api.Route {
+	namespace := p.opssight.Spec.Namespace
+	if strings.ToUpper(p.opssight.Spec.Perceptor.Expose) == util.OPENSHIFT {
+		return &api.Route{
+			Name:               fmt.Sprintf("%s-%s", p.opssight.Spec.Prometheus.Name, namespace),
+			Namespace:          namespace,
+			Kind:               "Service",
+			ServiceName:        p.opssight.Spec.Prometheus.Name,
+			PortName:           fmt.Sprintf("port-%s", p.opssight.Spec.Prometheus.Name),
+			Labels:             map[string]string{"app": "opssight"},
+			TLSTerminationType: routev1.TLSTerminationEdge,
+		}
+	}
+	return nil
 }

--- a/pkg/soperator/prometheus.go
+++ b/pkg/soperator/prometheus.go
@@ -62,5 +62,11 @@ func (specConfig *PrometheusSpecConfig) GetComponents() (*api.ComponentList, err
 			specConfig.GetPrometheusConfigMap(),
 		},
 	}
+
+	// Add routes for OpenShift
+	route := specConfig.GetOpenShiftRoute()
+	if route != nil {
+		components.Routes = []*api.Route{route}
+	}
 	return components, nil
 }

--- a/pkg/soperator/prometheus_resources.go
+++ b/pkg/soperator/prometheus_resources.go
@@ -27,7 +27,9 @@ import (
 
 	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	horizoncomponents "github.com/blackducksoftware/horizon/pkg/components"
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
+	routev1 "github.com/openshift/api/route/v1"
 )
 
 // GetPrometheusService creates a Horizon Service component for Prometheus
@@ -159,4 +161,20 @@ func (specConfig *PrometheusSpecConfig) GetPrometheusConfigMap() *horizoncompone
 
 	prometheusConfigMap.AddLabels(map[string]string{"app": "synopsys-operator", "component": "prometheus"})
 	return prometheusConfigMap
+}
+
+// GetOpenShiftRoute creates the OpenShift route component for the prometheus
+func (specConfig *PrometheusSpecConfig) GetOpenShiftRoute() *api.Route {
+	if strings.ToUpper(specConfig.Expose) == util.OPENSHIFT {
+		return &api.Route{
+			Name:               "synopsys-operator-prometheus",
+			Namespace:          specConfig.Namespace,
+			Kind:               "Service",
+			ServiceName:        "prometheus",
+			PortName:           "prometheus",
+			Labels:             map[string]string{"app": "synopsys-operator", "component": "prometheus"},
+			TLSTerminationType: routev1.TLSTerminationEdge,
+		}
+	}
+	return nil
 }

--- a/pkg/soperator/soperator.go
+++ b/pkg/soperator/soperator.go
@@ -113,5 +113,11 @@ func (specConfig *SpecConfig) GetComponents() (*api.ComponentList, error) {
 			specConfig.GetTLSCertificateSecret(),
 		},
 	}
+
+	// Add routes for OpenShift
+	route := specConfig.GetOpenShiftRoute()
+	if route != nil {
+		components.Routes = []*api.Route{route}
+	}
 	return components, nil
 }

--- a/pkg/soperator/soperator_resources.go
+++ b/pkg/soperator/soperator_resources.go
@@ -27,8 +27,10 @@ import (
 
 	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	horizoncomponents "github.com/blackducksoftware/horizon/pkg/components"
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	"github.com/juju/errors"
+	routev1 "github.com/openshift/api/route/v1"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -38,35 +40,18 @@ func (specConfig *SpecConfig) GetOperatorReplicationController() *horizoncompone
 	var synopsysOperatorRCReplicas int32 = 1
 	synopsysOperatorRC := horizoncomponents.NewReplicationController(horizonapi.ReplicationControllerConfig{
 		APIVersion: "v1",
-		//ClusterName:  "string",
-		Name:      "synopsys-operator",
-		Namespace: specConfig.Namespace,
-		Replicas:  &synopsysOperatorRCReplicas,
-		//ReadySeconds: "int32",
+		Name:       "synopsys-operator",
+		Namespace:  specConfig.Namespace,
+		Replicas:   &synopsysOperatorRCReplicas,
 	})
 
 	synopsysOperatorRC.AddLabelSelectors(map[string]string{"app": "synopsys-operator", "component": "operator"})
 
 	synopsysOperatorPod := horizoncomponents.NewPod(horizonapi.PodConfig{
-		APIVersion: "v1",
-		//ClusterName:            "string",
+		APIVersion:     "v1",
 		Name:           "synopsys-operator",
 		Namespace:      specConfig.Namespace,
 		ServiceAccount: "synopsys-operator",
-		//RestartPolicy:          "RestartPolicyType",
-		//TerminationGracePeriod: "*int64",
-		//ActiveDeadline:         "*int64",
-		//Node:                   "string",
-		//FSGID:                  "*int64",
-		//Hostname:               "string",
-		//SchedulerName:          "string",
-		//DNSPolicy:              "DNSPolicType",
-		//PriorityValue:          "*int32",
-		//PriorityClass:          "string",
-		//SELinux:                "*SELinuxType",
-		//RunAsUser:              "*int64",
-		//RunAsGroup:             "*int64",
-		//ForceNonRoot:           "*bool",
 	})
 
 	synopsysOperatorContainer := horizoncomponents.NewContainer(horizonapi.ContainerConfig{
@@ -75,28 +60,8 @@ func (specConfig *SpecConfig) GetOperatorReplicationController() *horizoncompone
 		Command:    []string{"./operator"},
 		Image:      specConfig.Image,
 		PullPolicy: horizonapi.PullAlways,
-		//MinCPU:                   "string",
-		//MaxCPU:                   "string",
-		//MinMem:                   "string",
-		//MaxMem:                   "string",
-		//Privileged:               "*bool",
-		//AllowPrivilegeEscalation: "*bool",
-		//ReadOnlyFS:               "*bool",
-		//ForceNonRoot:             "*bool",
-		//SELinux:                  "*SELinuxType",
-		//UID:                      "*int64",
-		//AllocateStdin:            "bool",
-		//StdinOnce:                "bool",
-		//AllocateTTY:              "bool",
-		//WorkingDirectory:         "string",
-		//TerminationMsgPath:       "string",
-		//TerminationMsgPolicy:     "TerminationMessagePolicyType",
 	})
 	synopsysOperatorContainer.AddPort(horizonapi.PortConfig{
-		//Name:          "string",
-		//Protocol:      "ProtocolType",
-		//IP:            "string",
-		//HostPort:      "string",
 		ContainerPort: "8080",
 	})
 	synopsysOperatorContainer.AddVolumeMount(horizonapi.VolumeMountConfig{
@@ -115,52 +80,28 @@ func (specConfig *SpecConfig) GetOperatorReplicationController() *horizoncompone
 	})
 
 	synopsysOperatorContainerUI := horizoncomponents.NewContainer(horizonapi.ContainerConfig{
-		Name: "synopsys-operator-ui",
-		//Args:                     "[]string",
+		Name:       "synopsys-operator-ui",
 		Command:    []string{"./app"},
 		Image:      specConfig.Image,
 		PullPolicy: horizonapi.PullAlways,
-		//MinCPU:                   "string",
-		//MaxCPU:                   "string",
-		//MinMem:                   "string",
-		//MaxMem:                   "string",
-		//Privileged:               "*bool",
-		//AllowPrivilegeEscalation: "*bool",
-		//ReadOnlyFS:               "*bool",
-		//ForceNonRoot:             "*bool",
-		//SELinux:                  "*SELinuxType",
-		//UID:                      "*int64",
-		//AllocateStdin:            "bool",
-		//StdinOnce:                "bool",
-		//AllocateTTY:              "bool",
-		//WorkingDirectory:         "string",
-		//TerminationMsgPath:       "string",
-		//TerminationMsgPolicy:     "TerminationMessagePolicyType",
 	})
 	synopsysOperatorContainerUI.AddPort(horizonapi.PortConfig{
-		//Name:          "string",
-		//Protocol:      "ProtocolType",
-		//IP:            "string",
-		//HostPort:      "string",
 		ContainerPort: "3000",
 	})
 	synopsysOperatorContainerUI.AddEnv(horizonapi.EnvConfig{
 		NameOrPrefix: "ADDR",
 		Type:         horizonapi.EnvVal,
 		KeyOrVal:     "0.0.0.0",
-		//FromName:     "string",
 	})
 	synopsysOperatorContainerUI.AddEnv(horizonapi.EnvConfig{
 		NameOrPrefix: "PORT",
 		Type:         horizonapi.EnvVal,
 		KeyOrVal:     "3000",
-		//FromName:     "string",
 	})
 	synopsysOperatorContainerUI.AddEnv(horizonapi.EnvConfig{
 		NameOrPrefix: "GO_ENV",
 		Type:         horizonapi.EnvVal,
 		KeyOrVal:     "development",
-		//FromName:     "string",
 	})
 
 	// Create config map volume
@@ -421,7 +362,7 @@ func (specConfig *SpecConfig) GetOperatorClusterRole() *horizoncomponents.Cluste
 		})
 
 		synopsysOperatorClusterRole.AddPolicyRule(horizonapi.PolicyRuleConfig{
-			Verbs:           []string{"get", "create"},
+			Verbs:           []string{"get", "list", "create", "delete", "deletecollection"},
 			APIGroups:       []string{"route.openshift.io"},
 			Resources:       []string{"routes"},
 			ResourceNames:   []string{},
@@ -478,4 +419,20 @@ func (specConfig *SpecConfig) GetOperatorSecret() *horizoncomponents.Secret {
 
 	synopsysOperatorSecret.AddLabels(map[string]string{"app": "synopsys-operator", "component": "operator"})
 	return synopsysOperatorSecret
+}
+
+// GetOpenShiftRoute creates the OpenShift route component for the synopsys operator
+func (specConfig *SpecConfig) GetOpenShiftRoute() *api.Route {
+	if strings.ToUpper(specConfig.Expose) == util.OPENSHIFT {
+		return &api.Route{
+			Name:               "synopsys-operator-ui",
+			Namespace:          specConfig.Namespace,
+			Kind:               "Service",
+			ServiceName:        "synopsys-operator",
+			PortName:           "synopsys-operator-ui",
+			Labels:             map[string]string{"app": "synopsys-operator", "component": "operator"},
+			TLSTerminationType: routev1.TLSTerminationEdge,
+		}
+	}
+	return nil
 }

--- a/pkg/synopsysctl/cmd_deploy.go
+++ b/pkg/synopsysctl/cmd_deploy.go
@@ -28,17 +28,9 @@ import (
 
 	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	soperator "github.com/blackducksoftware/synopsys-operator/pkg/soperator"
-	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	operatorutil "github.com/blackducksoftware/synopsys-operator/pkg/util"
-	routev1 "github.com/openshift/api/route/v1"
-	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-)
-
-const (
-	// OPENSHIFT denotes to create an OpenShift routes
-	OPENSHIFT = "OPENSHIFT"
 )
 
 //  Deploy Command Defaults
@@ -136,34 +128,6 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			log.Errorf("error deploying Prometheus: %s", err)
 			return nil
-		}
-
-		routeClient, err := routeclient.NewForConfig(restconfig)
-		// expose the routes
-		if strings.ToUpper(exposeUI) == OPENSHIFT {
-			log.Infof("creating openshift routes for the synopsys operator user interface")
-			if err != nil {
-				log.Errorf("unable to create the route client due to %+v", err)
-				return nil
-			}
-			_, err = util.CreateOpenShiftRoutes(routeClient, deployNamespace, "synopsys-operator-ui", "Service", "synopsys-operator", "synopsys-operator-ui", routev1.TLSTerminationEdge)
-			if err != nil {
-				log.Warnf("could not create route (possible reason: kubernetes doesn't support routes) due to %+v", err)
-			}
-		}
-
-		// expose the metrics routes
-		if strings.ToUpper(exposePrometheusMetrics) == OPENSHIFT {
-			log.Infof("creating openshift routes for the synopsys operator prometheus metrics")
-			routeClient, err := routeclient.NewForConfig(restconfig)
-			if err != nil {
-				log.Errorf("unable to create the route client due to %+v", err)
-				return nil
-			}
-			_, err = util.CreateOpenShiftRoutes(routeClient, deployNamespace, "synopsys-operator-prometheus", "Service", "prometheus", "prometheus", routev1.TLSTerminationEdge)
-			if err != nil {
-				log.Warnf("could not create route (possible reason: kubernetes doesn't support routes) due to %+v", err)
-			}
 		}
 
 		log.Infof("successfully deployed the synopsys operator")

--- a/pkg/synopsysctl/cmd_describe.go
+++ b/pkg/synopsysctl/cmd_describe.go
@@ -50,15 +50,15 @@ var describeBlackduckCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Debugf("Describing a Blackduck")
-		kCmd := []string{"describe", "blackducks"}
+		kubectlCmd := []string{"describe", "blackducks"}
 		if len(args) > 0 {
-			kCmd = append(kCmd, args...)
+			kubectlCmd = append(kubectlCmd, args...)
 		}
 		if cmd.LocalFlags().Lookup("selector").Changed {
-			kCmd = append(kCmd, "-l")
-			kCmd = append(kCmd, describeSelector)
+			kubectlCmd = append(kubectlCmd, "-l")
+			kubectlCmd = append(kubectlCmd, describeSelector)
 		}
-		out, err := RunKubeCmd(restconfig, kube, openshift, kCmd...)
+		out, err := RunKubeCmd(restconfig, kube, openshift, kubectlCmd...)
 		if err != nil {
 			log.Errorf("error describing the Black Duck: %s - %s", out, err)
 			return nil
@@ -78,15 +78,15 @@ var describeOpsSightCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Debugf("Describing an OpsSight")
-		kCmd := []string{"describe", "opssights"}
+		kubectlCmd := []string{"describe", "opssights"}
 		if len(args) > 0 {
-			kCmd = append(kCmd, args...)
+			kubectlCmd = append(kubectlCmd, args...)
 		}
 		if cmd.LocalFlags().Lookup("selector").Changed {
-			kCmd = append(kCmd, "-l")
-			kCmd = append(kCmd, describeSelector)
+			kubectlCmd = append(kubectlCmd, "-l")
+			kubectlCmd = append(kubectlCmd, describeSelector)
 		}
-		out, err := RunKubeCmd(restconfig, kube, openshift, kCmd...)
+		out, err := RunKubeCmd(restconfig, kube, openshift, kubectlCmd...)
 		if err != nil {
 			log.Errorf("error describing the OpsSight: %s - %s", out, err)
 			return nil
@@ -106,15 +106,15 @@ var describeAlertCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Debugf("Describing an Alert")
-		kCmd := []string{"describe", "alerts"}
+		kubectlCmd := []string{"describe", "alerts"}
 		if len(args) > 0 {
-			kCmd = append(kCmd, args...)
+			kubectlCmd = append(kubectlCmd, args...)
 		}
 		if cmd.LocalFlags().Lookup("selector").Changed {
-			kCmd = append(kCmd, "-l")
-			kCmd = append(kCmd, describeSelector)
+			kubectlCmd = append(kubectlCmd, "-l")
+			kubectlCmd = append(kubectlCmd, describeSelector)
 		}
-		out, err := RunKubeCmd(restconfig, kube, openshift, kCmd...)
+		out, err := RunKubeCmd(restconfig, kube, openshift, kubectlCmd...)
 		if err != nil {
 			log.Errorf("error describing the Alert: %s - %s", out, err)
 			return nil

--- a/pkg/synopsysctl/cmd_destroy.go
+++ b/pkg/synopsysctl/cmd_destroy.go
@@ -50,17 +50,16 @@ var destroyCmd = &cobra.Command{
 		if err != nil {
 			log.Warnf("error finding synopsys operator due to %+v", err)
 		}
-		log.Infof("Destroying the Synopsys-Operator '%s'...", destroyNamespace)
+		log.Infof("destroying the synopsys operator in '%s' namespace...", destroyNamespace)
 
 		// delete  namespace
-		log.Debugf("Deleting namespace %s", destroyNamespace)
+		log.Debugf("deleting namespace %s", destroyNamespace)
 		err = util.DeleteNamespace(kubeClient, destroyNamespace)
 		if err != nil {
 			log.Warnf("Unable to delete the %s namespace because %+v", destroyNamespace, err)
 		}
 
 		// delete crds
-		log.Debugf("Deleting CRDs")
 		apiExtensionClient, err := apiextensionsclient.NewForConfig(restconfig)
 		if err != nil {
 			log.Errorf("error creating the api extension client due to %+v", err)
@@ -69,6 +68,7 @@ var destroyCmd = &cobra.Command{
 		crds := []string{"alerts.synopsys.com", "blackducks.synopsys.com", "opssights.synopsys.com"}
 
 		for _, crd := range crds {
+			log.Infof("deleting %s CRD", crd)
 			err = util.DeleteCustomResourceDefinition(apiExtensionClient, crd)
 			if err != nil {
 				log.Warnf("Unable to delete the %s crd because %+v", crd, err)
@@ -76,20 +76,20 @@ var destroyCmd = &cobra.Command{
 		}
 
 		// delete cluster role bindings
-		log.Debugf("Deleting ClusterRoleBinding")
+		log.Infof("deleting synopsys-operator-admin cluster role binding")
 		err = util.DeleteClusterRoleBinding(kubeClient, "synopsys-operator-admin")
 		if err != nil {
 			log.Warnf("Unable to delete the synopsys-operator-admin cluster role binding because %+v", err)
 		}
 
 		// delete cluster roles
-		log.Debugf("Deleting ClusterRoles")
+		log.Infof("deleting synopsys-operator-admin cluster role ")
 		err = util.DeleteClusterRole(kubeClient, "synopsys-operator-admin")
 		if err != nil {
 			log.Warnf("Unable to delete the synopsys-operator-admin cluster role because %+v", err)
 		}
 
-		log.Infof("Finished destroying synopsys-operator: '%s'", destroyNamespace)
+		log.Infof("finished destroying synopsys operator in '%s' namespace", destroyNamespace)
 		return nil
 	},
 }

--- a/pkg/synopsysctl/cmd_get.go
+++ b/pkg/synopsysctl/cmd_get.go
@@ -58,19 +58,19 @@ var getBlackduckCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Debugf("getting Black Ducks...")
-		kCmd := []string{"get", "blackducks"}
+		kubectlCmd := []string{"get", "blackducks"}
 		if len(args) > 0 {
-			kCmd = append(kCmd, args...)
+			kubectlCmd = append(kubectlCmd, args...)
 		}
 		if cmd.LocalFlags().Lookup("output").Changed {
-			kCmd = append(kCmd, "-o")
-			kCmd = append(kCmd, getOutputFormat)
+			kubectlCmd = append(kubectlCmd, "-o")
+			kubectlCmd = append(kubectlCmd, getOutputFormat)
 		}
 		if cmd.LocalFlags().Lookup("selector").Changed {
-			kCmd = append(kCmd, "-l")
-			kCmd = append(kCmd, getSelector)
+			kubectlCmd = append(kubectlCmd, "-l")
+			kubectlCmd = append(kubectlCmd, getSelector)
 		}
-		out, err := RunKubeCmd(restconfig, kube, openshift, kCmd...)
+		out, err := RunKubeCmd(restconfig, kube, openshift, kubectlCmd...)
 		if err != nil {
 			log.Errorf("error getting Black Ducks due to %+v - %s", out, err)
 			return nil
@@ -150,19 +150,19 @@ var getOpsSightCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Debugf("getting OpsSights...")
-		kCmd := []string{"get", "opssights"}
+		kubectlCmd := []string{"get", "opssights"}
 		if len(args) > 0 {
-			kCmd = append(kCmd, args...)
+			kubectlCmd = append(kubectlCmd, args...)
 		}
 		if cmd.LocalFlags().Lookup("output").Changed {
-			kCmd = append(kCmd, "-o")
-			kCmd = append(kCmd, getOutputFormat)
+			kubectlCmd = append(kubectlCmd, "-o")
+			kubectlCmd = append(kubectlCmd, getOutputFormat)
 		}
 		if cmd.LocalFlags().Lookup("selector").Changed {
-			kCmd = append(kCmd, "-l")
-			kCmd = append(kCmd, getSelector)
+			kubectlCmd = append(kubectlCmd, "-l")
+			kubectlCmd = append(kubectlCmd, getSelector)
 		}
-		out, err := RunKubeCmd(restconfig, kube, openshift, kCmd...)
+		out, err := RunKubeCmd(restconfig, kube, openshift, kubectlCmd...)
 		if err != nil {
 			log.Errorf("error getting OpsSights due to %+v - %s", out, err)
 			return nil
@@ -182,19 +182,19 @@ var getAlertCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Debugf("getting Alerts...")
-		kCmd := []string{"get", "alerts"}
+		kubectlCmd := []string{"get", "alerts"}
 		if len(args) > 0 {
-			kCmd = append(kCmd, args...)
+			kubectlCmd = append(kubectlCmd, args...)
 		}
 		if cmd.LocalFlags().Lookup("output").Changed {
-			kCmd = append(kCmd, "-o")
-			kCmd = append(kCmd, getOutputFormat)
+			kubectlCmd = append(kubectlCmd, "-o")
+			kubectlCmd = append(kubectlCmd, getOutputFormat)
 		}
 		if cmd.LocalFlags().Lookup("selector").Changed {
-			kCmd = append(kCmd, "-l")
-			kCmd = append(kCmd, getSelector)
+			kubectlCmd = append(kubectlCmd, "-l")
+			kubectlCmd = append(kubectlCmd, getSelector)
 		}
-		out, err := RunKubeCmd(restconfig, kube, openshift, kCmd...)
+		out, err := RunKubeCmd(restconfig, kube, openshift, kubectlCmd...)
 		if err != nil {
 			log.Errorf("error getting Alerts due to %+v - %s", out, err)
 			return nil

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -38,8 +38,6 @@ import (
 	soperator "github.com/blackducksoftware/synopsys-operator/pkg/soperator"
 	operatorutil "github.com/blackducksoftware/synopsys-operator/pkg/util"
 	"github.com/imdario/mergo"
-	routev1 "github.com/openshift/api/route/v1"
-	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -211,38 +209,6 @@ var updateOperatorCmd = &cobra.Command{
 			return nil
 		}
 
-		routeClient, err := routeclient.NewForConfig(restconfig)
-		// expose the routes
-		if strings.ToUpper(updateExposeUI) == OPENSHIFT {
-			if err != nil {
-				log.Errorf("unable to create the route client due to %+v", err)
-				return nil
-			}
-			_, err = operatorutil.GetOpenShiftRoutes(routeClient, namespace, "synopsys-operator-ui")
-			if err != nil {
-				log.Infof("creating openshift routes for the synopsys operator user interface")
-				_, err = operatorutil.CreateOpenShiftRoutes(routeClient, namespace, "synopsys-operator-ui", "Service", "synopsys-operator", "synopsys-operator-ui", routev1.TLSTerminationEdge)
-				if err != nil {
-					log.Warnf("could not create route (possible reason: kubernetes doesn't support routes) due to %+v", err)
-				}
-			}
-		}
-
-		// expose the metrics routes
-		if strings.ToUpper(updateExposePrometheusMetrics) == OPENSHIFT {
-			if err != nil {
-				log.Errorf("unable to create the route client due to %+v", err)
-				return nil
-			}
-			_, err = operatorutil.GetOpenShiftRoutes(routeClient, namespace, "synopsys-operator-prometheus")
-			if err != nil {
-				log.Infof("creating openshift routes for the synopsys operator prometheus metrics")
-				_, err = operatorutil.CreateOpenShiftRoutes(routeClient, namespace, "synopsys-operator-prometheus", "Service", "prometheus", "prometheus", routev1.TLSTerminationEdge)
-				if err != nil {
-					log.Warnf("could not create route (possible reason: kubernetes doesn't support routes) due to %+v", err)
-				}
-			}
-		}
 		log.Infof("successfully updated the synopsys operator in '%s' namespace", namespace)
 		return nil
 	},


### PR DESCRIPTION
* Incorporated all OpenShift route issues in OpsSight, Alert, Black Duck and Operator
* Incorporated #243
* Incorporated #244
* Incorporated OpenShift router and image registry service
* get route client fixed
* modified crud updater patch service
* error handling crud updater
* add list and delete permissions to cluster role
* improved log statements
* patch for cluster role and role bindings
* Incorporated #95
* Incorporated opssight prometheus deployment and perceptor scanner fix