### PR TITLE
buffalo build dep and default cert fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM gobuffalo/buffalo:v0.13.5 as builder
 
+RUN go get -u github.com/golang/dep/cmd/dep
+
 # Set the environment
 ENV BP=$GOPATH/src/github.com/blackducksoftware/synopsys-operator
 
@@ -13,8 +15,7 @@ WORKDIR $BP
 RUN cd cmd/operator && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/operator
 
 ### BUILD THE UI
-WORKDIR $BP/cmd/operator-ui
-RUN yarn install --no-progress && mkdir -p public/assets && dep ensure && buffalo build --static -o /bin/app
+RUN cd cmd/operator-ui && yarn install --no-progress && mkdir -p public/assets && dep ensure && buffalo build --static -o /bin/app
 
 # Container catalog requirements
 COPY ./LICENSE /bin/LICENSE 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ init:
 	brew install npm
 
 container:
-	docker build -f Dockerfile-Operator . --pull -t $(REGISTRY)/synopsys-operator:$(TAG) --build-arg VERSION=$(TAG) --build-arg 'BUILDTIME=$(BUILD_TIME)' --build-arg LASTCOMMIT=$(LAST_COMMIT)
+	docker build . --pull -t $(REGISTRY)/synopsys-operator:$(TAG) --build-arg VERSION=$(TAG) --build-arg 'BUILDTIME=$(BUILD_TIME)' --build-arg LASTCOMMIT=$(LAST_COMMIT)
 
 push: container
 	$(PREFIX_CMD) docker $(DOCKER_OPTS) push $(REGISTRY)/synopsys-operator:$(TAG)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 #### BUILD OPERATOR/BLACKDUCKCTL
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-f', Dockerfile-Operator, '-t', 'gcr.io/$PROJECT_ID/blackducksoftware/synopsys-operator:$BRANCH_NAME', '.']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/blackducksoftware/synopsys-operator:$BRANCH_NAME', '.']
 #### PUSH ARTIFACTS TO DOCKER HUB / GCS 
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/blackducksoftware/synopsys-operator:$BRANCH_NAME']

--- a/pkg/apps/blackduck/latest/deployer.go
+++ b/pkg/apps/blackduck/latest/deployer.go
@@ -237,7 +237,8 @@ func (hc *Creater) getTLSCertKeyOrCreate(blackduck *blackduckapi.Blackduck) (str
 		return blackduck.Spec.Certificate, blackduck.Spec.CertificateKey, nil
 	}
 
-	secret, err := util.GetSecret(hc.KubeClient, blackduck.Spec.Namespace, "blackduck-certificate")
+	// default cert
+	secret, err := util.GetSecret(hc.KubeClient, hc.Config.Namespace, "blackduck-certificate")
 	if err == nil {
 		data := secret.Data
 		if len(data) >= 2 {

--- a/pkg/apps/blackduck/v1/deployer.go
+++ b/pkg/apps/blackduck/v1/deployer.go
@@ -234,7 +234,8 @@ func (hc *Creater) getTLSCertKeyOrCreate(blackduck *blackduckapi.Blackduck) (str
 		return blackduck.Spec.Certificate, blackduck.Spec.CertificateKey, nil
 	}
 
-	secret, err := util.GetSecret(hc.KubeClient, blackduck.Spec.Namespace, "blackduck-certificate")
+	// default cert
+	secret, err := util.GetSecret(hc.KubeClient, hc.Config.Namespace, "blackduck-certificate")
 	if err == nil {
 		data := secret.Data
 		if len(data) >= 2 {


### PR DESCRIPTION
* update the dep version in Dockerfile
* if the default cert name is specified, get the cert from synopsys-operator instead of creating it new (#323)