### PR TITLE
require postgres passwords

### DIFF
--- a/pkg/alert/ctl_alert.go
+++ b/pkg/alert/ctl_alert.go
@@ -77,7 +77,7 @@ func (ctl *Ctl) SetSpec(spec interface{}) error {
 }
 
 // CheckSpecFlags returns an error if a user input was invalid
-func (ctl *Ctl) CheckSpecFlags() error {
+func (ctl *Ctl) CheckSpecFlags(flagset *pflag.FlagSet) error {
 	encryptPassLength := len(ctl.EncryptionPassword)
 	if encryptPassLength > 0 && encryptPassLength < 16 {
 		return fmt.Errorf("flag EncryptionPassword is %d characters. Must be 16 or more characters", encryptPassLength)

--- a/pkg/alert/ctl_alert_test.go
+++ b/pkg/alert/ctl_alert_test.go
@@ -59,7 +59,8 @@ func TestSetSpec(t *testing.T) {
 func TestCheckSpecFlags(t *testing.T) {
 	assert := assert.New(t)
 	alertCtl := NewAlertCtl()
-	specFlags := alertCtl.CheckSpecFlags()
+	cmd := &cobra.Command{}
+	specFlags := alertCtl.CheckSpecFlags(cmd.Flags())
 	assert.Nil(specFlags)
 }
 

--- a/pkg/api/blackduck/v1/types.go
+++ b/pkg/api/blackduck/v1/types.go
@@ -73,6 +73,9 @@ type BlackduckSpec struct {
 	ImageUIDMap           map[string]int64          `json:"imageUidMap,omitempty"`
 	LicenseKey            string                    `json:"licenseKey,omitempty"`
 	RegistryConfiguration RegistryConfiguration     `json:"registryConfiguration,omitempty"`
+	AdminPassword         string                    `json:"adminPassword"`
+	UserPassword          string                    `json:"userPassword"`
+	PostgresPassword      string                    `json:"postgresPassword"`
 }
 
 // Environs will hold the list of Environment variables

--- a/pkg/api/opssight/v1/types.go
+++ b/pkg/api/opssight/v1/types.go
@@ -22,7 +22,7 @@ under the License.
 package v1
 
 import (
-	"github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+	v1 "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -60,6 +60,7 @@ type Host struct {
 type Blackduck struct {
 	ExternalHosts                      []*Host `json:"externalHosts"`
 	ConnectionsEnvironmentVariableName string  `json:"connectionsEnvironmentVariableName"`
+	BlackduckPassword                  string  `json:"blackduckPassword"`
 	TLSVerification                    bool    `json:"tlsVerification"`
 
 	// Auto scaling parameters

--- a/pkg/apps/blackduck/v1/creater.go
+++ b/pkg/apps/blackduck/v1/creater.go
@@ -26,8 +26,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"math"
 	"net/http"
 	"reflect"
 	"strings"
@@ -45,6 +43,7 @@ import (
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -225,18 +224,17 @@ func (hc *Creater) getContainersFlavor(bd *blackduckapi.Blackduck) (*containers.
 }
 
 func (hc *Creater) initPostgres(bdspec *blackduckapi.BlackduckSpec) error {
-	var adminPassword, userPassword, postgresPassword string
-	var err error
-
-	for dbInitTry := 0; dbInitTry < math.MaxInt32; dbInitTry++ {
-		// get the secret from the default operator namespace, then copy it into the hub namespace.
-		adminPassword, userPassword, postgresPassword, err = bdutils.GetDefaultPasswords(hc.KubeClient, hc.Config.Namespace)
-		if err == nil {
-			break
-		} else {
-			log.Infof("[%s] wasn't able to init database, sleeping 5 seconds.  try = %v", bdspec.Namespace, dbInitTry)
-			time.Sleep(5 * time.Second)
-		}
+	adminPassword, err := util.Base64Decode(bdspec.AdminPassword)
+	if err != nil {
+		return fmt.Errorf("%v: unable to decode adminPassword due to: %+v", bdspec.Namespace, err)
+	}
+	userPassword, err := util.Base64Decode(bdspec.UserPassword)
+	if err != nil {
+		return fmt.Errorf("%v: unable to decode userPassword due to: %+v", bdspec.Namespace, err)
+	}
+	postgresPassword, err := util.Base64Decode(bdspec.PostgresPassword)
+	if err != nil {
+		return fmt.Errorf("%v: unable to decode postgresPassword due to: %+v", bdspec.Namespace, err)
 	}
 
 	ready, err := util.WaitUntilPodsAreReady(hc.KubeClient, bdspec.Namespace, "app=blackduck,component=postgres", hc.Config.PodWaitTimeoutSeconds)

--- a/pkg/apps/blackduck/v1/deployer.go
+++ b/pkg/apps/blackduck/v1/deployer.go
@@ -31,7 +31,6 @@ import (
 	"github.com/blackducksoftware/synopsys-operator/pkg/api"
 	blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
 	containers "github.com/blackducksoftware/synopsys-operator/pkg/apps/blackduck/v1/containers"
-	bdutil "github.com/blackducksoftware/synopsys-operator/pkg/blackduck/util"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	"github.com/juju/errors"
 	log "github.com/sirupsen/logrus"
@@ -51,13 +50,29 @@ func (hc *Creater) getPostgresComponents(blackduck *blackduckapi.Blackduck) (*ap
 	// Get Db creds
 	var adminPassword, userPassword string
 	if blackduck.Spec.ExternalPostgres != nil {
-		adminPassword = blackduck.Spec.ExternalPostgres.PostgresAdminPassword
-		userPassword = blackduck.Spec.ExternalPostgres.PostgresUserPassword
-	} else {
-		adminPassword, userPassword, _, err = bdutil.GetDefaultPasswords(hc.KubeClient, hc.Config.Namespace)
+
+		adminPassword, err = util.Base64Decode(blackduck.Spec.ExternalPostgres.PostgresAdminPassword)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%v: unable to decode external Postgres adminPassword due to: %+v", blackduck.Spec.Namespace, err)
 		}
+
+		userPassword, err = util.Base64Decode(blackduck.Spec.ExternalPostgres.PostgresUserPassword)
+		if err != nil {
+			return nil, fmt.Errorf("%v: unable to decode external Postgres userPassword due to: %+v", blackduck.Spec.Namespace, err)
+		}
+
+	} else {
+
+		adminPassword, err = util.Base64Decode(blackduck.Spec.AdminPassword)
+		if err != nil {
+			return nil, fmt.Errorf("%v: unable to decode adminPassword due to: %+v", blackduck.Spec.Namespace, err)
+		}
+
+		userPassword, err = util.Base64Decode(blackduck.Spec.UserPassword)
+		if err != nil {
+			return nil, fmt.Errorf("%v: unable to decode userPassword due to: %+v", blackduck.Spec.Namespace, err)
+		}
+
 	}
 
 	postgres := containerCreater.GetPostgres()

--- a/pkg/blackduck/ctl_blackduck_test.go
+++ b/pkg/blackduck/ctl_blackduck_test.go
@@ -60,8 +60,9 @@ func TestCheckSpecFlags(t *testing.T) {
 	assert := assert.New(t)
 
 	// default case
-	blackDuckCtl := NewBlackDuckCtl()
-	assert.Nil(blackDuckCtl.CheckSpecFlags())
+	blackduckCtl := NewBlackDuckCtl()
+	cmd := &cobra.Command{}
+	assert.Nil(blackduckCtl.CheckSpecFlags(cmd.Flags()))
 
 	var tests = []struct {
 		input *Ctl
@@ -79,7 +80,7 @@ func TestCheckSpecFlags(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		assert.Error(test.input.CheckSpecFlags())
+		assert.Error(test.input.CheckSpecFlags(cmd.Flags()))
 	}
 }
 func TestSwitchSpec(t *testing.T) {
@@ -125,13 +126,13 @@ func TestAddSpecFlags(t *testing.T) {
 	cmd.Flags().StringVar(&ctl.Version, "version", ctl.Version, "Version of Black Duck")
 	cmd.Flags().StringVar(&ctl.ExposeService, "expose-ui", ctl.ExposeService, "Service type of Black Duck Webserver's user interface [LOADBALANCER|NODEPORT|OPENSHIFT]")
 	cmd.Flags().StringVar(&ctl.DbPrototype, "db-prototype", ctl.DbPrototype, "Black Duck name to clone the database")
-	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresHost, "external-postgres-host", ctl.ExternalPostgresPostgresHost, "Host for Postgres")
-	cmd.Flags().IntVar(&ctl.ExternalPostgresPostgresPort, "external-postgres-port", ctl.ExternalPostgresPostgresPort, "Port for Postgres")
-	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresAdmin, "external-postgres-admin", ctl.ExternalPostgresPostgresAdmin, "Name of Admin for Postgres")
-	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresUser, "external-postgres-user", ctl.ExternalPostgresPostgresUser, "Username for Postgres")
-	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresSsl, "external-postgres-ssl", ctl.ExternalPostgresPostgresSsl, "If true, Black Duck uses SSL for the Postgres connection [true|false]")
-	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresAdminPassword, "external-postgres-admin-password", ctl.ExternalPostgresPostgresAdminPassword, "Password for the Postgres Admin")
-	cmd.Flags().StringVar(&ctl.ExternalPostgresPostgresUserPassword, "external-postgres-user-password", ctl.ExternalPostgresPostgresUserPassword, "Password for a Postgres User")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresHost, "external-postgres-host", ctl.ExternalPostgresHost, "Host of external Postgres")
+	cmd.Flags().IntVar(&ctl.ExternalPostgresPort, "external-postgres-port", ctl.ExternalPostgresPort, "Port of external Postgres")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresAdmin, "external-postgres-admin", ctl.ExternalPostgresAdmin, "Name of 'admin' of external Postgres database")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresUser, "external-postgres-user", ctl.ExternalPostgresUser, "Name of 'user' of external Postgres database")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresSsl, "external-postgres-ssl", ctl.ExternalPostgresSsl, "If true, Black Duck uses SSL for external Postgres connection [true|false]")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresAdminPassword, "external-postgres-admin-password", ctl.ExternalPostgresAdminPassword, "'admin' password of external Postgres database")
+	cmd.Flags().StringVar(&ctl.ExternalPostgresUserPassword, "external-postgres-user-password", ctl.ExternalPostgresUserPassword, "'user' password of external Postgres database")
 	cmd.Flags().StringVar(&ctl.PvcStorageClass, "pvc-storage-class", ctl.PvcStorageClass, "Name of Storage Class for the PVC")
 	cmd.Flags().StringVar(&ctl.LivenessProbes, "liveness-probes", ctl.LivenessProbes, "If true, Black Duck uses liveness probes [true|false]")
 	cmd.Flags().StringVar(&ctl.PersistentStorage, "persistent-storage", ctl.PersistentStorage, "If true, Black duck has persistent storage [true|false]")
@@ -148,6 +149,9 @@ func TestAddSpecFlags(t *testing.T) {
 	cmd.Flags().StringSliceVar(&ctl.ImageRegistries, "image-registries", ctl.ImageRegistries, "List of image registries")
 	cmd.Flags().StringVar(&ctl.ImageUIDMapFilePath, "image-uid-map-file-path", ctl.ImageUIDMapFilePath, "Absolute path to a file containing a map of Container UIDs to Tags")
 	cmd.Flags().StringVar(&ctl.LicenseKey, "license-key", ctl.LicenseKey, "License Key of Black Duck")
+	cmd.Flags().StringVar(&ctl.AdminPassword, "admin-password", ctl.AdminPassword, "'admin' password of Postgres database")
+	cmd.Flags().StringVar(&ctl.PostgresPassword, "postgres-password", ctl.PostgresPassword, "'postgres' password of Postgres database")
+	cmd.Flags().StringVar(&ctl.UserPassword, "user-password", ctl.UserPassword, "'user' password of Postgres database")
 
 	// TODO: Remove this flag in next release
 	cmd.Flags().MarkDeprecated("desired-state", "desired-state flag is deprecated and will be removed by the next release")
@@ -223,8 +227,8 @@ func TestSetFlag(t *testing.T) {
 			flagName:   "external-postgres-host",
 			initialCtl: NewBlackDuckCtl(),
 			changedCtl: &Ctl{
-				Spec:                         &blackduckv1.BlackduckSpec{},
-				ExternalPostgresPostgresHost: "changed",
+				Spec:                 &blackduckv1.BlackduckSpec{},
+				ExternalPostgresHost: "changed",
 			},
 			changedSpec: &blackduckv1.BlackduckSpec{
 				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
@@ -235,8 +239,8 @@ func TestSetFlag(t *testing.T) {
 			flagName:   "external-postgres-port",
 			initialCtl: NewBlackDuckCtl(),
 			changedCtl: &Ctl{
-				Spec:                         &blackduckv1.BlackduckSpec{},
-				ExternalPostgresPostgresPort: 10,
+				Spec:                 &blackduckv1.BlackduckSpec{},
+				ExternalPostgresPort: 10,
 			},
 			changedSpec: &blackduckv1.BlackduckSpec{
 				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
@@ -247,8 +251,8 @@ func TestSetFlag(t *testing.T) {
 			flagName:   "external-postgres-admin",
 			initialCtl: NewBlackDuckCtl(),
 			changedCtl: &Ctl{
-				Spec:                          &blackduckv1.BlackduckSpec{},
-				ExternalPostgresPostgresAdmin: "changed",
+				Spec:                  &blackduckv1.BlackduckSpec{},
+				ExternalPostgresAdmin: "changed",
 			},
 			changedSpec: &blackduckv1.BlackduckSpec{
 				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
@@ -259,8 +263,8 @@ func TestSetFlag(t *testing.T) {
 			flagName:   "external-postgres-user",
 			initialCtl: NewBlackDuckCtl(),
 			changedCtl: &Ctl{
-				Spec:                         &blackduckv1.BlackduckSpec{},
-				ExternalPostgresPostgresUser: "changed",
+				Spec:                 &blackduckv1.BlackduckSpec{},
+				ExternalPostgresUser: "changed",
 			},
 			changedSpec: &blackduckv1.BlackduckSpec{
 				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
@@ -271,8 +275,8 @@ func TestSetFlag(t *testing.T) {
 			flagName:   "external-postgres-ssl",
 			initialCtl: NewBlackDuckCtl(),
 			changedCtl: &Ctl{
-				Spec:                        &blackduckv1.BlackduckSpec{},
-				ExternalPostgresPostgresSsl: "false",
+				Spec:                &blackduckv1.BlackduckSpec{},
+				ExternalPostgresSsl: "false",
 			},
 			changedSpec: &blackduckv1.BlackduckSpec{
 				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
@@ -283,8 +287,8 @@ func TestSetFlag(t *testing.T) {
 			flagName:   "external-postgres-ssl",
 			initialCtl: NewBlackDuckCtl(),
 			changedCtl: &Ctl{
-				Spec:                        &blackduckv1.BlackduckSpec{},
-				ExternalPostgresPostgresSsl: "true",
+				Spec:                &blackduckv1.BlackduckSpec{},
+				ExternalPostgresSsl: "true",
 			},
 			changedSpec: &blackduckv1.BlackduckSpec{
 				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
@@ -295,24 +299,24 @@ func TestSetFlag(t *testing.T) {
 			flagName:   "external-postgres-admin-password",
 			initialCtl: NewBlackDuckCtl(),
 			changedCtl: &Ctl{
-				Spec:                                  &blackduckv1.BlackduckSpec{},
-				ExternalPostgresPostgresAdminPassword: "changed",
+				Spec:                          &blackduckv1.BlackduckSpec{},
+				ExternalPostgresAdminPassword: "changed",
 			},
 			changedSpec: &blackduckv1.BlackduckSpec{
 				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
-					PostgresAdminPassword: "changed"}},
+					PostgresAdminPassword: crddefaults.Base64Encode([]byte("changed"))}},
 		},
 		// case
 		{
 			flagName:   "external-postgres-user-password",
 			initialCtl: NewBlackDuckCtl(),
 			changedCtl: &Ctl{
-				Spec:                                 &blackduckv1.BlackduckSpec{},
-				ExternalPostgresPostgresUserPassword: "changed",
+				Spec:                         &blackduckv1.BlackduckSpec{},
+				ExternalPostgresUserPassword: "changed",
 			},
 			changedSpec: &blackduckv1.BlackduckSpec{
 				ExternalPostgres: &blackduckv1.PostgresExternalDBConfig{
-					PostgresUserPassword: "changed"}},
+					PostgresUserPassword: crddefaults.Base64Encode([]byte("changed"))}},
 		},
 		// case
 		{

--- a/pkg/blackduck/util/helpers.go
+++ b/pkg/blackduck/util/helpers.go
@@ -29,7 +29,6 @@ import (
 	blackduckv1 "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
 	blackduckclient "github.com/blackducksoftware/synopsys-operator/pkg/blackduck/client/clientset/versioned"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,23 +100,6 @@ func intArrayToStringArray(intArr []int32, delim string) string {
 		strArr = append(strArr, fmt.Sprintf("<<NODE_IP_ADDRESS>>:%+v", intArr[i]))
 	}
 	return strings.Join(strArr, delim)
-}
-
-// GetDefaultPasswords returns admin,user,postgres passwords for db maintainance tasks.  Should only be used during
-// initialization, or for 'babysitting' ephemeral hub instances (which might have postgres restarts)
-// MAKE SURE YOU SEND THE NAMESPACE OF THE SECRET SOURCE (operator), NOT OF THE new hub  THAT YOUR TRYING TO CREATE !
-func GetDefaultPasswords(kubeClient *kubernetes.Clientset, nsOfSecretHolder string) (adminPassword string, userPassword string, postgresPassword string, err error) {
-	blackduckSecret, err := util.GetSecret(kubeClient, nsOfSecretHolder, "blackduck-secret")
-	if err != nil {
-		log.Infof("warning: You need to first create a 'blackduck-secret' in this namespace with ADMIN_PASSWORD, USER_PASSWORD, POSTGRES_PASSWORD")
-		return "", "", "", err
-	}
-	adminPassword = string(blackduckSecret.Data["ADMIN_PASSWORD"])
-	userPassword = string(blackduckSecret.Data["USER_PASSWORD"])
-	postgresPassword = string(blackduckSecret.Data["POSTGRES_PASSWORD"])
-
-	// default named return
-	return adminPassword, userPassword, postgresPassword, err
 }
 
 func updateHubObject(h *blackduckclient.Clientset, namespace string, obj *blackduckv1.Blackduck) (*blackduckv1.Blackduck, error) {

--- a/pkg/opssight/creater.go
+++ b/pkg/opssight/creater.go
@@ -229,20 +229,6 @@ func (ac *Creater) UpdateOpsSight(opssight *opssightapi.OpsSight) error {
 	return ac.CreateOpsSight(opssight)
 }
 
-// GetDefaultPasswords returns admin,user,postgres passwords for db maintainance tasks.  Should only be used during
-// initialization, or for 'babysitting' ephemeral hub instances (which might have postgres restarts)
-// MAKE SURE YOU SEND THE NAMESPACE OF THE SECRET SOURCE (operator), NOT OF THE new hub  THAT YOUR TRYING TO CREATE !
-func GetDefaultPasswords(kubeClient *kubernetes.Clientset, nsOfSecretHolder string) (hubPassword string, err error) {
-	blackduckSecret, err := util.GetSecret(kubeClient, nsOfSecretHolder, "blackduck-secret")
-	if err != nil {
-		return "", errors.Annotate(err, "You need to first create a 'blackduck-secret' in this namespace with HUB_PASSWORD")
-	}
-	hubPassword = string(blackduckSecret.Data["HUB_PASSWORD"])
-
-	// default named return
-	return hubPassword, nil
-}
-
 func (ac *Creater) addRegistryAuth(opsSightSpec *opssightapi.OpsSightSpec) {
 	// if OpenShift, get the registry auth informations
 	if ac.routeClient == nil {

--- a/pkg/opssight/ctl_opssight.go
+++ b/pkg/opssight/ctl_opssight.go
@@ -97,7 +97,7 @@ type Ctl struct {
 	BlackduckExternalHostsFilePath                  string
 	BlackduckConnectionsEnvironmentVaraiableName    string
 	BlackduckTLSVerification                        string
-	BlackduckPasswordEnvVar                         string
+	BlackduckPassword                               string
 	BlackduckInitialCount                           int
 	BlackduckMaxCount                               int
 	BlackduckType                                   string
@@ -126,11 +126,11 @@ func (ctl *Ctl) SetSpec(spec interface{}) error {
 }
 
 // CheckSpecFlags returns an error if a user input was invalid
-func (ctl *Ctl) CheckSpecFlags() error {
+func (ctl *Ctl) CheckSpecFlags(flagset *pflag.FlagSet) error {
 	return nil
 }
 
-// Constants for Default Specs
+// Constants
 const (
 	EmptySpec             string = "empty"
 	UpstreamSpec          string = "upstream"
@@ -200,6 +200,7 @@ func (ctl *Ctl) AddSpecFlags(cmd *cobra.Command, master bool) {
 	cmd.Flags().IntVar(&ctl.BlackduckInitialCount, "blackduck-initial-count", ctl.BlackduckInitialCount, "Initial number of Black Ducks to create")
 	cmd.Flags().IntVar(&ctl.BlackduckMaxCount, "blackduck-max-count", ctl.BlackduckMaxCount, "Maximum number of Black Ducks that can be created")
 	cmd.Flags().StringVar(&ctl.BlackduckType, "blackduck-type", ctl.BlackduckType, "Type of Black Duck")
+	cmd.Flags().StringVar(&ctl.BlackduckPassword, "blackduck-password", ctl.BlackduckPassword, "Password to use for all internal Blackduck `sysadmin` account")
 }
 
 // SetChangedFlags visits every flag and calls setFlag to update
@@ -441,6 +442,14 @@ func (ctl *Ctl) SetFlag(f *pflag.Flag) {
 				ctl.Spec.Blackduck.BlackduckSpec = &blackduckapi.BlackduckSpec{}
 			}
 			ctl.Spec.Blackduck.BlackduckSpec.Type = ctl.BlackduckType
+		case "blackduck-password":
+			if ctl.Spec.Blackduck == nil {
+				ctl.Spec.Blackduck = &opssightapi.Blackduck{}
+			}
+			if ctl.Spec.Blackduck.BlackduckSpec == nil {
+				ctl.Spec.Blackduck.BlackduckSpec = &blackduckapi.BlackduckSpec{}
+			}
+			ctl.Spec.Blackduck.BlackduckPassword = crddefaults.Base64Encode([]byte(ctl.BlackduckPassword))
 		default:
 			log.Debugf("flag %s: NOT FOUND", f.Name)
 		}

--- a/pkg/opssight/ctl_opssight_test.go
+++ b/pkg/opssight/ctl_opssight_test.go
@@ -60,7 +60,8 @@ func TestSetSpec(t *testing.T) {
 func TestCheckSpecFlags(t *testing.T) {
 	assert := assert.New(t)
 	opsSightCtl := NewOpsSightCtl()
-	specFlags := opsSightCtl.CheckSpecFlags()
+	cmd := &cobra.Command{}
+	specFlags := opsSightCtl.CheckSpecFlags(cmd.Flags())
 	assert.Nil(specFlags)
 }
 
@@ -137,6 +138,7 @@ func TestAddSpecFlags(t *testing.T) {
 	cmd.Flags().IntVar(&ctl.BlackduckInitialCount, "blackduck-initial-count", ctl.BlackduckInitialCount, "Initial number of Black Ducks to create")
 	cmd.Flags().IntVar(&ctl.BlackduckMaxCount, "blackduck-max-count", ctl.BlackduckMaxCount, "Maximum number of Black Ducks that can be created")
 	cmd.Flags().StringVar(&ctl.BlackduckType, "blackduck-type", ctl.BlackduckType, "Type of Black Duck")
+	cmd.Flags().StringVar(&ctl.BlackduckPassword, "blackduck-password", ctl.BlackduckPassword, "Password to use for all internal Blackduck `sysadmin` account")
 
 	assert.Equal(cmd.Flags(), actualCmd.Flags())
 

--- a/pkg/opssight/specconfig.go
+++ b/pkg/opssight/specconfig.go
@@ -289,7 +289,13 @@ func (p *SpecConfig) addSecretData(secret *components.Secret) error {
 
 	// adding Internal Black Duck credentials
 	secretEditor := NewUpdater(p.config, p.kubeClient, p.hubClient, p.opssightClient)
-	allHubs := secretEditor.getAllHubs(p.opssight.Spec.Blackduck.BlackduckSpec.Type)
+	hubType := p.opssight.Spec.Blackduck.BlackduckSpec.Type
+	blackduckPassword, err := util.Base64Decode(p.opssight.Spec.Blackduck.BlackduckPassword)
+	if err != nil {
+		return errors.Annotatef(err, "unable to decode blackduckPassword")
+	}
+
+	allHubs := secretEditor.getAllHubs(hubType, blackduckPassword)
 	blackduckPasswords := secretEditor.appendBlackDuckSecrets(blackduckHosts, p.opssight.Status.InternalHosts, allHubs)
 
 	// marshal the blackduck credentials to bytes

--- a/pkg/soperator/soperator.go
+++ b/pkg/soperator/soperator.go
@@ -22,7 +22,6 @@ under the License.
 package soperator
 
 import (
-	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	"github.com/blackducksoftware/horizon/pkg/components"
 	"github.com/blackducksoftware/synopsys-operator/pkg/api"
 	"github.com/juju/errors"
@@ -38,11 +37,6 @@ type SpecConfig struct {
 	Namespace                     string
 	Image                         string
 	Expose                        string
-	SecretType                    horizonapi.SecretType
-	AdminPassword                 string
-	PostgresPassword              string
-	UserPassword                  string
-	BlackduckPassword             string
 	OperatorTimeBombInSeconds     int64
 	DryRun                        bool
 	LogLevel                      string
@@ -59,19 +53,13 @@ type SpecConfig struct {
 }
 
 // NewSOperator will create a SOperator type
-func NewSOperator(namespace, synopsysOperatorImage, expose, adminPassword, postgresPassword, userPassword, blackduckpassword string,
-	secretType horizonapi.SecretType, operatorTimeBombInSeconds int64, dryRun bool, logLevel string, threadiness int, postgresRestartInMins int64,
+func NewSOperator(namespace, synopsysOperatorImage, expose string, operatorTimeBombInSeconds int64, dryRun bool, logLevel string, threadiness int, postgresRestartInMins int64,
 	podWaitTimeoutSeconds int64, resyncIntervalInSeconds int64, terminationGracePeriodSeconds int64, sealKey string, restConfig *rest.Config,
 	kubeClient *kubernetes.Clientset, certificate string, certificateKey string) *SpecConfig {
 	return &SpecConfig{
 		Namespace:                     namespace,
 		Image:                         synopsysOperatorImage,
 		Expose:                        expose,
-		SecretType:                    secretType,
-		AdminPassword:                 adminPassword,
-		PostgresPassword:              postgresPassword,
-		UserPassword:                  userPassword,
-		BlackduckPassword:             blackduckpassword,
 		OperatorTimeBombInSeconds:     operatorTimeBombInSeconds,
 		DryRun:                        dryRun,
 		LogLevel:                      logLevel,

--- a/pkg/soperator/soperator_resources.go
+++ b/pkg/soperator/soperator_resources.go
@@ -410,7 +410,7 @@ func (specConfig *SpecConfig) GetTLSCertificateSecret() *horizoncomponents.Secre
 	tlsSecret := horizoncomponents.NewSecret(horizonapi.SecretConfig{
 		Name:      "synopsys-operator-tls",
 		Namespace: specConfig.Namespace,
-		Type:      specConfig.SecretType,
+		Type:      horizonapi.SecretTypeOpaque,
 	})
 	tlsSecret.AddData(map[string][]byte{
 		"cert.crt": []byte(specConfig.Certificate),
@@ -428,14 +428,10 @@ func (specConfig *SpecConfig) GetOperatorSecret() *horizoncomponents.Secret {
 		APIVersion: "v1",
 		Name:       "blackduck-secret",
 		Namespace:  specConfig.Namespace,
-		Type:       specConfig.SecretType,
+		Type:       horizonapi.SecretTypeOpaque,
 	})
 	synopsysOperatorSecret.AddData(map[string][]byte{
-		"ADMIN_PASSWORD":    []byte(specConfig.AdminPassword),
-		"POSTGRES_PASSWORD": []byte(specConfig.PostgresPassword),
-		"USER_PASSWORD":     []byte(specConfig.UserPassword),
-		"HUB_PASSWORD":      []byte(specConfig.BlackduckPassword),
-		"SEAL_KEY":          []byte(specConfig.SealKey),
+		"SEAL_KEY": []byte(specConfig.SealKey),
 	})
 
 	synopsysOperatorSecret.AddLabels(map[string]string{"app": "synopsys-operator", "component": "operator"})

--- a/pkg/soperator/utils.go
+++ b/pkg/soperator/utils.go
@@ -125,17 +125,7 @@ func GetOldOperatorSpec(restConfig *rest.Config, kubeClient *kubernetes.Clientse
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Synopsys Operator secret: %s", err)
 	}
-	currKubeSecret := currSecret.Type
-	currHorizonSecretType, err := operatorutil.KubeSecretTypeToHorizon(currKubeSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Synopsys Operator spec: %s", err)
-	}
-	sOperatorSpec.SecretType = currHorizonSecretType
 	currKubeSecretData := currSecret.Data
-	sOperatorSpec.AdminPassword = string(currKubeSecretData["ADMIN_PASSWORD"])
-	sOperatorSpec.PostgresPassword = string(currKubeSecretData["POSTGRES_PASSWORD"])
-	sOperatorSpec.UserPassword = string(currKubeSecretData["USER_PASSWORD"])
-	sOperatorSpec.BlackduckPassword = string(currKubeSecretData["HUB_PASSWORD"])
 	sealKey := string(currKubeSecretData["SEAL_KEY"])
 	if len(sealKey) == 0 {
 		sealKey, err = operatorutil.GetRandomString(32)

--- a/pkg/synopsysctl/cmd_create.go
+++ b/pkg/synopsysctl/cmd_create.go
@@ -68,7 +68,8 @@ var createAlertCmd = &cobra.Command{
 		if len(args) != 1 {
 			return fmt.Errorf("this command takes 1 argument")
 		}
-		err := createAlertCtl.CheckSpecFlags()
+		// Check the Arguments
+		err := createAlertCtl.CheckSpecFlags(cmd.Flags())
 		if err != nil {
 			return fmt.Errorf("%s", err)
 		}
@@ -141,7 +142,7 @@ var createBlackDuckCmd = &cobra.Command{
 			return fmt.Errorf("this command takes 1 argument")
 		}
 		// Check the Arguments
-		err := createBlackDuckCtl.CheckSpecFlags()
+		err := createBlackDuckCtl.CheckSpecFlags(cmd.Flags())
 		if err != nil {
 			return fmt.Errorf("%s", err)
 		}
@@ -215,7 +216,7 @@ var createOpsSightCmd = &cobra.Command{
 			return fmt.Errorf("this command takes 1 argument")
 		}
 		// Check the Arguments
-		err := createOpsSightCtl.CheckSpecFlags()
+		err := createOpsSightCtl.CheckSpecFlags(cmd.Flags())
 		if err != nil {
 			return fmt.Errorf("%s", err)
 		}

--- a/pkg/synopsysctl/cmd_deploy.go
+++ b/pkg/synopsysctl/cmd_deploy.go
@@ -46,11 +46,6 @@ var threadiness = 5
 var postgresRestartInMins int64 = 10
 var podWaitTimeoutSeconds int64 = 600
 var resyncIntervalInSeconds int64 = 120
-var deploySecretType = "Opaque"
-var adminPassword = "blackduck"
-var postgresPassword = "blackduck"
-var userPassword = "blackduck"
-var blackDuckPassword = "blackduck"
 
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
@@ -61,13 +56,6 @@ var deployCmd = &cobra.Command{
 		// Check number of arguments
 		if len(args) > 1 {
 			return fmt.Errorf("this command takes up to 1 argument")
-		}
-		// Check the Secret Type
-		var err error
-		secretType, err = operatorutil.SecretTypeNameToHorizon(deploySecretType)
-		if err != nil {
-			log.Errorf("failed to convert secret type: %s", err)
-			return nil
 		}
 		return nil
 	},
@@ -117,9 +105,9 @@ var deployCmd = &cobra.Command{
 		}
 
 		// Deploy Synopsys Operator
-		log.Debugf("creating Synopsys Operator components")
-		soperatorSpec := soperator.NewSOperator(deployNamespace, synopsysOperatorImage, exposeUI, adminPassword, postgresPassword,
-			userPassword, blackDuckPassword, secretType, operatorTimeBombInSeconds, strings.ToUpper(dryRun) == "TRUE", logLevel, threadiness, postgresRestartInMins,
+		log.Debugf("creating Synopsys-Operator components")
+		soperatorSpec := soperator.NewSOperator(deployNamespace, synopsysOperatorImage, exposeUI,
+			operatorTimeBombInSeconds, strings.ToUpper(dryRun) == "TRUE", logLevel, threadiness, postgresRestartInMins,
 			podWaitTimeoutSeconds, resyncIntervalInSeconds, terminationGracePeriodSeconds, sealKey, restconfig, kubeClient, cert, key)
 
 		err = soperatorSpec.UpdateSOperatorComponents()
@@ -148,11 +136,6 @@ func init() {
 	deployCmd.Flags().StringVarP(&synopsysOperatorImage, "synopsys-operator-image", "i", DefaultOperatorImage, "Image URL of Synopsys Operator")
 	deployCmd.Flags().StringVarP(&exposeMetrics, "expose-metrics", "m", exposeMetrics, "Service type to expose Synopsys Operator's metrics application [NODEPORT|LOADBALANCER|OPENSHIFT]")
 	deployCmd.Flags().StringVarP(&metricsImage, "metrics-image", "k", DefaultMetricsImage, "Image URL of Synopsys Operator's metrics pod")
-	deployCmd.Flags().StringVar(&deploySecretType, "secret-type", deploySecretType, "Type of kubernetes secret to store the postgres and Black Duck credentials")
-	deployCmd.Flags().StringVarP(&adminPassword, "admin-password", "a", adminPassword, "Postgres admin password")
-	deployCmd.Flags().StringVarP(&postgresPassword, "postgres-password", "p", postgresPassword, "Postgres password")
-	deployCmd.Flags().StringVarP(&userPassword, "user-password", "u", userPassword, "Postgres user password")
-	deployCmd.Flags().StringVarP(&blackDuckPassword, "blackduck-password", "b", blackDuckPassword, "Black Duck password of 'sysadmin' account")
 	deployCmd.Flags().Int64VarP(&operatorTimeBombInSeconds, "operator-time-bomb-in-seconds", "o", operatorTimeBombInSeconds, "Termination grace period in seconds for shutting down crds")
 	deployCmd.Flags().Int64VarP(&postgresRestartInMins, "postgres-restart-in-minutes", "n", postgresRestartInMins, "Minutes to check for restarting postgres")
 	deployCmd.Flags().Int64VarP(&podWaitTimeoutSeconds, "pod-wait-timeout-in-seconds", "w", podWaitTimeoutSeconds, "Seconds to wait for pods to be running")

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -51,10 +51,6 @@ var updateOpsSightCtl ResourceCtl
 // Update Comamnd Defaults
 var updateSynopsysOperatorImage = ""
 var updatePrometheusImage = ""
-var updateSecretAdminPassword = ""
-var updateSecretPostgresPassword = ""
-var updateSecretUserPassword = ""
-var updateSecretBlackduckPassword = ""
 var updateExposeUI = ""
 var updateExposePrometheusMetrics = ""
 var updateTerminationGracePeriodSeconds int64
@@ -113,22 +109,6 @@ var updateOperatorCmd = &cobra.Command{
 				return nil
 			}
 			newOperatorSpec.Image = updateSynopsysOperatorImage
-		}
-		if cmd.Flag("admin-password").Changed {
-			log.Debugf("updating admin password")
-			newOperatorSpec.AdminPassword = updateSecretAdminPassword
-		}
-		if cmd.Flag("postgres-password").Changed {
-			log.Debugf("updating postgres password")
-			newOperatorSpec.PostgresPassword = updateSecretPostgresPassword
-		}
-		if cmd.Flag("user-password").Changed {
-			log.Debugf("updating user password")
-			newOperatorSpec.UserPassword = updateSecretUserPassword
-		}
-		if cmd.Flag("blackduck-password").Changed {
-			log.Debugf("updating Black Duck password")
-			newOperatorSpec.BlackduckPassword = updateSecretBlackduckPassword
 		}
 		if cmd.Flag("expose-ui").Changed {
 			log.Debugf("updating expose ui")
@@ -863,10 +843,6 @@ func init() {
 	updateOperatorCmd.Flags().StringVarP(&updateSynopsysOperatorImage, "synopsys-operator-image", "i", updateSynopsysOperatorImage, "Synopsys Operator image URL")
 	updateOperatorCmd.Flags().StringVarP(&updateExposePrometheusMetrics, "expose-prometheus-metrics", "m", updateExposePrometheusMetrics, "Expose Synopsys Operator's prometheus metrics. possible values are [NODEPORT|LOADBALANCER|OPENSHIFT]")
 	updateOperatorCmd.Flags().StringVarP(&updatePrometheusImage, "prometheus-image", "k", updatePrometheusImage, "Prometheus image URL")
-	updateOperatorCmd.Flags().StringVarP(&updateSecretAdminPassword, "admin-password", "a", updateSecretAdminPassword, "Postgres admin password")
-	updateOperatorCmd.Flags().StringVarP(&updateSecretPostgresPassword, "postgres-password", "p", updateSecretPostgresPassword, "Postgres password")
-	updateOperatorCmd.Flags().StringVarP(&updateSecretUserPassword, "user-password", "u", updateSecretUserPassword, "Postgres user password")
-	updateOperatorCmd.Flags().StringVarP(&updateSecretBlackduckPassword, "blackduck-password", "b", updateSecretBlackduckPassword, "Black Duck password for 'sysadmin' account")
 	updateOperatorCmd.Flags().Int64VarP(&updateOperatorTimeBombInSeconds, "operator-time-bomb-in-seconds", "o", updateOperatorTimeBombInSeconds, "Termination grace period in seconds for shutting down crds")
 	updateOperatorCmd.Flags().Int64VarP(&updatePostgresRestartInMins, "postgres-restart-in-minutes", "n", updatePostgresRestartInMins, "Check for postgres restart in minutes")
 	updateOperatorCmd.Flags().Int64VarP(&updatePodWaitTimeoutSeconds, "pod-wait-timeout-in-seconds", "w", updatePodWaitTimeoutSeconds, "Wait for pod to be running in seconds")

--- a/pkg/synopsysctl/ctl_interface.go
+++ b/pkg/synopsysctl/ctl_interface.go
@@ -29,13 +29,13 @@ import (
 // ResourceCtl interface defines functions that other
 // ctl types for resources should define
 type ResourceCtl interface {
-	CheckSpecFlags() error             // returns an error if a flag format is invalid
-	GetSpec() interface{}              // returns spec for the resource
-	SetSpec(interface{}) error         // sets the spec
-	SwitchSpec(string) error           // change the spec for the resource
-	AddSpecFlags(*cobra.Command, bool) // Add flags for the resource spec
-	SetChangedFlags(*pflag.FlagSet)    // calls setFlag on each flag in flagset
-	SetFlag(*pflag.Flag)               // updates the spec value for the flag
-	SpecIsValid() (bool, error)        // verifies the spec has necessary fields to deploy
-	CanUpdate() (bool, error)          // checks if a user has permission to modify based on the spec
+	CheckSpecFlags(*pflag.FlagSet) error // returns an error if a flag format is invalid
+	GetSpec() interface{}                // returns spec for the resource
+	SetSpec(interface{}) error           // sets the spec
+	SwitchSpec(string) error             // change the spec for the resource
+	AddSpecFlags(*cobra.Command, bool)   // Add flags for the resource spec
+	SetChangedFlags(*pflag.FlagSet)      // calls setFlag on each flag in flagset
+	SetFlag(*pflag.Flag)                 // updates the spec value for the flag
+	SpecIsValid() (bool, error)          // verifies the spec has necessary fields to deploy
+	CanUpdate() (bool, error)            // checks if a user has permission to modify based on the spec
 }

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -892,10 +892,22 @@ func getBytes(n int) ([]byte, error) {
 	return b, nil
 }
 
+// Base64Encode will return an encoded string using a URL-compatible base64 format
+func Base64Encode(data []byte) string {
+	return base64.URLEncoding.EncodeToString(data)
+}
+
+// Base64Decode will return a decoded string using a URL-compatible base64 format;
+// decoding may return an error, which you can check if you don’t already know the input to be well-formed.
+func Base64Decode(data string) (string, error) {
+	uDec, err := base64.URLEncoding.DecodeString(data)
+	return string(uDec), err
+}
+
 // RandomString will generate the random string
 func RandomString(n int) (string, error) {
 	b, err := getBytes(n)
-	return base64.URLEncoding.EncodeToString(b), err
+	return Base64Encode(b), err
 }
 
 // CreateServiceAccount creates a service account


### PR DESCRIPTION
Now, synopsysctl will require postgres passwords for 'user', 'admin', and 'postgres' when customer deploys the operator and will not give update options for those passwords in scope of issue #326

For reference, this is the error customer will see when deploying the operator and not providing those passwords
<img width="1637" alt="image" src="https://user-images.githubusercontent.com/5788514/57542963-0f573800-7321-11e9-9af2-1289c06f9283.png">

For reference, no longer is there an option to update the postgres passwords.  Customer will have to maintain them themselves.
<img width="1637" alt="image" src="https://user-images.githubusercontent.com/5788514/57543053-4299c700-7321-11e9-989b-6dccf7620157.png">

