### PR TITLE
Make starting the admission webhook listener optional

### DIFF
--- a/cmd/operator/run.go
+++ b/cmd/operator/run.go
@@ -108,9 +108,11 @@ func runProtoform(configPath string) {
 		logrus.Errorf("ran into errors during deployment, but continuing anyway: %s", err.Error())
 	}
 
-	go func() {
-		webhook.NewOperatorWebhook(deployer.KubeConfig).Start()
-	}()
+	if deployer.Config.AdmissionWebhookListener {
+		go func() {
+			webhook.NewOperatorWebhook(deployer.KubeConfig).Start()
+		}()
+	}
 
 	// Start the prometheus endpoint
 	protoform.SetupHTTPServer()

--- a/pkg/protoform/config.go
+++ b/pkg/protoform/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	PodWaitTimeoutSeconds         int64
 	ResyncIntervalInSeconds       int64
 	TerminationGracePeriodSeconds int64
-
+	AdmissionWebhookListener      bool
 	// Not recommended production, just for testing, QA, resiliency, and CI/CD.
 	OperatorTimeBombInSeconds int64
 }
@@ -100,6 +100,7 @@ func GetConfig(configPath string) (*Config, error) {
 		viper.BindEnv("ResyncIntervalInSeconds")
 		viper.BindEnv("TerminationGracePeriodSeconds")
 		viper.BindEnv("OperatorTimeBombInSeconds")
+		viper.BindEnv("AdmissionWebhookListener")
 		viper.AutomaticEnv()
 	}
 

--- a/pkg/soperator/soperator_components.go
+++ b/pkg/soperator/soperator_components.go
@@ -49,12 +49,13 @@ type SpecConfig struct {
 	SealKey                       string
 	Certificate                   string
 	CertificateKey                string
+	AdmissionWebhookListener      bool
 }
 
 // NewSOperator will create a SOperator type
 func NewSOperator(namespace, synopsysOperatorImage, expose string, clusterType ClusterType, operatorTimeBombInSeconds int64, dryRun bool, logLevel string, threadiness int, postgresRestartInMins int64,
 	podWaitTimeoutSeconds int64, resyncIntervalInSeconds int64, terminationGracePeriodSeconds int64, sealKey string, restConfig *rest.Config,
-	kubeClient *kubernetes.Clientset, certificate string, certificateKey string) *SpecConfig {
+	kubeClient *kubernetes.Clientset, certificate string, certificateKey string, admissionWebhookListener bool) *SpecConfig {
 	return &SpecConfig{
 		Namespace:                     namespace,
 		Image:                         synopsysOperatorImage,
@@ -71,6 +72,7 @@ func NewSOperator(namespace, synopsysOperatorImage, expose string, clusterType C
 		SealKey:                       sealKey,
 		Certificate:                   certificate,
 		CertificateKey:                certificateKey,
+		AdmissionWebhookListener:      admissionWebhookListener,
 	}
 }
 

--- a/pkg/soperator/soperator_resources.go
+++ b/pkg/soperator/soperator_resources.go
@@ -242,6 +242,7 @@ func (specConfig *SpecConfig) GetOperatorConfigMap() (*horizoncomponents.ConfigM
 		"PodWaitTimeoutSeconds":         specConfig.PodWaitTimeoutSeconds,
 		"ResyncIntervalInSeconds":       specConfig.ResyncIntervalInSeconds,
 		"TerminationGracePeriodSeconds": specConfig.TerminationGracePeriodSeconds,
+		"AdmissionWebhookListener":      specConfig.AdmissionWebhookListener,
 	}
 	bytes, err := json.Marshal(configData)
 	if err != nil {

--- a/pkg/synopsysctl/cmd_deploy.go
+++ b/pkg/synopsysctl/cmd_deploy.go
@@ -47,6 +47,7 @@ var threadiness = 5
 var postgresRestartInMins int64 = 10
 var podWaitTimeoutSeconds int64 = 600
 var resyncIntervalInSeconds int64 = 120
+var admissionWebhookListener = false
 
 // Flags for using mock mode - doesn't deploy
 var deployMockFormat string
@@ -116,7 +117,7 @@ var deployCmd = &cobra.Command{
 		log.Debugf("creating Synopsys Operator components")
 		soperatorSpec := soperator.NewSOperator(deployNamespace, synopsysOperatorImage, exposeUI, soperator.GetClusterType(restconfig),
 			operatorTimeBombInSeconds, strings.ToUpper(dryRun) == "TRUE", logLevel, threadiness, postgresRestartInMins,
-			podWaitTimeoutSeconds, resyncIntervalInSeconds, terminationGracePeriodSeconds, sealKey, restconfig, kubeClient, cert, key)
+			podWaitTimeoutSeconds, resyncIntervalInSeconds, terminationGracePeriodSeconds, sealKey, restconfig, kubeClient, cert, key, admissionWebhookListener)
 
 		if cmd.LocalFlags().Lookup("mock").Changed {
 			log.Debugf("running mock mode")


### PR DESCRIPTION
Since we cannot currently rely on the admission webhooks, the listener will be disabled by default and no flag is added to synopsysctl to enable it (for now). However, if needed, the listener can be re-enabled in the config.json. 

/assign @msenmurugan 
/assign @mphammer 