### PR TITLE
Synopsysctl mock-kube mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	k8s.io/klog v0.3.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208 // indirect
 	k8s.io/utils v0.0.0-20190529001817-6999998975a7 // indirect
-	sigs.k8s.io/yaml v1.1.0 // indirect
+	sigs.k8s.io/yaml v1.1.0
 )
 
 replace (

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -50,3 +50,36 @@ type ComponentList struct {
 	PersistentVolumeClaims []*components.PersistentVolumeClaim
 	Routes                 []*Route
 }
+
+// GetKubeInterfaces returns a list of kube components as interfaces
+func (clist *ComponentList) GetKubeInterfaces() []interface{} {
+	components := []interface{}{}
+	for _, rc := range clist.ReplicationControllers {
+		components = append(components, rc.ReplicationController)
+	}
+	for _, svc := range clist.Services {
+		components = append(components, svc.Service)
+	}
+	for _, cm := range clist.ConfigMaps {
+		components = append(components, cm.ConfigMap)
+	}
+	for _, sa := range clist.ServiceAccounts {
+		components = append(components, sa.ServiceAccount)
+	}
+	for _, crb := range clist.ClusterRoleBindings {
+		components = append(components, crb.ClusterRoleBinding)
+	}
+	for _, cr := range clist.ClusterRoles {
+		components = append(components, cr.ClusterRole)
+	}
+	for _, d := range clist.Deployments {
+		components = append(components, d.Deployment)
+	}
+	for _, sec := range clist.Secrets {
+		components = append(components, sec.Secret)
+	}
+	for _, pvc := range clist.PersistentVolumeClaims {
+		components = append(components, pvc.PersistentVolumeClaim)
+	}
+	return components
+}

--- a/pkg/apps/alert/alert.go
+++ b/pkg/apps/alert/alert.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	alertclientset "github.com/blackducksoftware/synopsys-operator/pkg/alert/client/clientset/versioned"
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
 	alertapi "github.com/blackducksoftware/synopsys-operator/pkg/api/alert/v1"
 	latestalert "github.com/blackducksoftware/synopsys-operator/pkg/apps/alert/latest"
 	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
@@ -144,4 +145,13 @@ func (a *Alert) Delete(namespace string) error {
 		time.Sleep(retryWait * time.Second)
 	}
 	return nil
+}
+
+// GetComponents gets the necessary creater and returns the Alert's components
+func (a *Alert) GetComponents(alert *alertapi.Alert) (*api.ComponentList, error) {
+	creater, err := a.getCreater(alert.Spec.Version) // get Creater for the Alert Version
+	if err != nil {
+		return nil, err
+	}
+	return creater.GetComponents(alert)
 }

--- a/pkg/apps/alert/creater_interface.go
+++ b/pkg/apps/alert/creater_interface.go
@@ -22,6 +22,7 @@ under the License.
 package alert
 
 import (
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
 	alertapi "github.com/blackducksoftware/synopsys-operator/pkg/api/alert/v1"
 )
 
@@ -31,4 +32,5 @@ import (
 type Creater interface {
 	Versions() []string
 	Ensure(alert *alertapi.Alert) error
+	GetComponents(alert *alertapi.Alert) (*api.ComponentList, error)
 }

--- a/pkg/apps/alert/latest/alert_creater.go
+++ b/pkg/apps/alert/latest/alert_creater.go
@@ -49,6 +49,12 @@ func NewCreater(config *protoform.Config, kubeConfig *rest.Config, kubeClient *k
 	return &Creater{Config: config, KubeConfig: kubeConfig, KubeClient: kubeClient, AlertClient: alertClient, RouteClient: routeClient}
 }
 
+// GetComponents returns the resource components for an Alert
+func (ac *Creater) GetComponents(alert *alertapi.Alert) (*api.ComponentList, error) {
+	specConfig := NewSpecConfig(&alert.Spec)
+	return specConfig.GetComponents()
+}
+
 // Versions is an Interface function that returns the versions supported by this Creater
 func (ac *Creater) Versions() []string {
 	return GetVersions()

--- a/pkg/apps/alert/latest/alertsecret.go
+++ b/pkg/apps/alert/latest/alertsecret.go
@@ -43,10 +43,9 @@ func (a *SpecConfig) GetAlertSecret() (*components.Secret, error) {
 	// create a secret
 	alertSecret := components.NewSecret(horizonapi.SecretConfig{
 		APIVersion: "v1",
-		// ClusterName : "cluster",
-		Name:      "alert-secret",
-		Namespace: a.config.Namespace,
-		Type:      horizonapi.SecretTypeOpaque,
+		Name:       "alert-secret",
+		Namespace:  a.config.Namespace,
+		Type:       horizonapi.SecretTypeOpaque,
 	})
 	alertSecret.AddData(map[string][]byte{
 		"ALERT_ENCRYPTION_PASSWORD":    []byte(a.config.EncryptionPassword),

--- a/pkg/apps/alert/latest/route.go
+++ b/pkg/apps/alert/latest/route.go
@@ -39,7 +39,7 @@ func (a *SpecConfig) GetOpenShiftRoute() *api.Route {
 			Kind:               "Service",
 			ServiceName:        "alert",
 			PortName:           fmt.Sprintf("%d-tcp", *a.config.Port),
-			Labels:             map[string]string{"app": "alert"},
+			Labels:             map[string]string{"app": "alert", "component": "alert"},
 			TLSTerminationType: routev1.TLSTerminationPassthrough,
 		}
 	}

--- a/pkg/apps/blackduck/blackduck.go
+++ b/pkg/apps/blackduck/blackduck.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
+	blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
 	v1 "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
 	latestblackduck "github.com/blackducksoftware/synopsys-operator/pkg/apps/blackduck/latest"
 	v1blackduck "github.com/blackducksoftware/synopsys-operator/pkg/apps/blackduck/v1"
@@ -148,4 +150,13 @@ func (b Blackduck) Ensure(bd *v1.Blackduck) error {
 	}
 
 	return creater.Ensure(bd)
+}
+
+// GetComponents gets the BlackDuck's creater and returns the components
+func (b Blackduck) GetComponents(bd *blackduckapi.Blackduck) (*api.ComponentList, error) {
+	creater, err := b.getCreater(bd.Spec.Version)
+	if err != nil {
+		return nil, err
+	}
+	return creater.GetComponents(bd)
 }

--- a/pkg/apps/blackduck/interface.go
+++ b/pkg/apps/blackduck/interface.go
@@ -21,10 +21,14 @@ under the License.
 
 package blackduck
 
-import blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+import (
+	"github.com/blackducksoftware/synopsys-operator/pkg/api"
+	blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+)
 
 // Creater interface
 type Creater interface {
 	Ensure(blackduck *blackduckapi.Blackduck) error
 	Versions() []string
+	GetComponents(alert *blackduckapi.Blackduck) (*api.ComponentList, error)
 }

--- a/pkg/apps/blackduck/latest/containers/clusterrolebinding.go
+++ b/pkg/apps/blackduck/latest/containers/clusterrolebinding.go
@@ -29,11 +29,6 @@ import (
 
 // GetClusterRoleBinding will return the cluster role binding
 func (c *Creater) GetClusterRoleBinding() (*components.ClusterRoleBinding, error) {
-	clusterRole, err := util.GetOperatorClusterRole(c.kubeClient)
-	if err != nil {
-		return nil, err
-	}
-
 	clusterRoleBinding := components.NewClusterRoleBinding(horizonapi.ClusterRoleBindingConfig{
 		Name:       "blackduck",
 		APIVersion: "rbac.authorization.k8s.io/v1",
@@ -44,6 +39,11 @@ func (c *Creater) GetClusterRoleBinding() (*components.ClusterRoleBinding, error
 		Name:      c.hubSpec.Namespace,
 		Namespace: c.hubSpec.Namespace,
 	})
+
+	clusterRole, err := util.GetOperatorClusterRole(c.kubeClient)
+	if err != nil {
+		return nil, err
+	}
 	clusterRoleBinding.AddRoleRef(horizonapi.RoleRefConfig{
 		APIGroup: "",
 		Kind:     "ClusterRole",

--- a/pkg/apps/blackduck/latest/creater.go
+++ b/pkg/apps/blackduck/latest/creater.go
@@ -30,9 +30,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/blackducksoftware/synopsys-operator/pkg/api"
 	blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
-	containers "github.com/blackducksoftware/synopsys-operator/pkg/apps/blackduck/latest/containers"
+	"github.com/blackducksoftware/synopsys-operator/pkg/apps/blackduck/latest/containers"
 	"github.com/blackducksoftware/synopsys-operator/pkg/apps/database"
 	blackduckclientset "github.com/blackducksoftware/synopsys-operator/pkg/blackduck/client/clientset/versioned"
 	bdutils "github.com/blackducksoftware/synopsys-operator/pkg/blackduck/util"
@@ -41,7 +43,6 @@ import (
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	securityclient "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -133,7 +134,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// Get non postgres components
-		cpList, err := hc.getComponents(blackduck)
+		cpList, err := hc.GetComponents(blackduck)
 		if err != nil {
 			return err
 		}

--- a/pkg/apps/blackduck/latest/init.go
+++ b/pkg/apps/blackduck/latest/init.go
@@ -28,7 +28,7 @@ import (
 	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	"github.com/blackducksoftware/horizon/pkg/components"
 	horizon "github.com/blackducksoftware/horizon/pkg/deployer"
-	"github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+	v1 "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
 	containers "github.com/blackducksoftware/synopsys-operator/pkg/apps/blackduck/latest/containers"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	log "github.com/sirupsen/logrus"

--- a/pkg/apps/blackduck/v1/containers/clusterrolebinding.go
+++ b/pkg/apps/blackduck/v1/containers/clusterrolebinding.go
@@ -29,11 +29,6 @@ import (
 
 // GetClusterRoleBinding will return the cluster role binding
 func (c *Creater) GetClusterRoleBinding() (*components.ClusterRoleBinding, error) {
-	clusterRole, err := util.GetOperatorClusterRole(c.kubeClient)
-	if err != nil {
-		return nil, err
-	}
-
 	clusterRoleBinding := components.NewClusterRoleBinding(horizonapi.ClusterRoleBindingConfig{
 		Name:       "blackduck",
 		APIVersion: "rbac.authorization.k8s.io/v1",
@@ -44,6 +39,11 @@ func (c *Creater) GetClusterRoleBinding() (*components.ClusterRoleBinding, error
 		Name:      c.hubSpec.Namespace,
 		Namespace: c.hubSpec.Namespace,
 	})
+
+	clusterRole, err := util.GetOperatorClusterRole(c.kubeClient)
+	if err != nil {
+		return nil, err
+	}
 	clusterRoleBinding.AddRoleRef(horizonapi.RoleRefConfig{
 		APIGroup: "",
 		Kind:     "ClusterRole",

--- a/pkg/apps/blackduck/v1/creater.go
+++ b/pkg/apps/blackduck/v1/creater.go
@@ -111,7 +111,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// Get non postgres components
-		cpList, err := hc.getComponents(blackduck)
+		cpList, err := hc.GetComponents(blackduck)
 		if err != nil {
 			return err
 		}

--- a/pkg/apps/blackduck/v1/deployer.go
+++ b/pkg/apps/blackduck/v1/deployer.go
@@ -95,8 +95,8 @@ func (hc *Creater) getPostgresComponents(blackduck *blackduckapi.Blackduck) (*ap
 	return componentList, nil
 }
 
-// getComponents returns the components
-func (hc *Creater) getComponents(blackduck *blackduckapi.Blackduck) (*api.ComponentList, error) {
+// GetComponents returns the components
+func (hc *Creater) GetComponents(blackduck *blackduckapi.Blackduck) (*api.ComponentList, error) {
 
 	componentList := &api.ComponentList{}
 
@@ -232,11 +232,15 @@ func (hc *Creater) getComponents(blackduck *blackduckapi.Blackduck) (*api.Compon
 
 	//Service account
 	componentList.ServiceAccounts = append(componentList.ServiceAccounts, containerCreater.GetServiceAccount())
-	clusterRoleBinding, err := containerCreater.GetClusterRoleBinding()
-	if err != nil {
-		return nil, err
+
+	// Cluster Role Binding
+	if !hc.Config.DryRun {
+		clusterRoleBinding, err := containerCreater.GetClusterRoleBinding()
+		if err != nil {
+			return nil, err
+		}
+		componentList.ClusterRoleBindings = append(componentList.ClusterRoleBindings, clusterRoleBinding)
 	}
-	componentList.ClusterRoleBindings = append(componentList.ClusterRoleBindings, clusterRoleBinding)
 
 	if hc.isBinaryAnalysisEnabled(&blackduck.Spec) {
 		// Upload cache

--- a/pkg/apps/blackduck/v1/init.go
+++ b/pkg/apps/blackduck/v1/init.go
@@ -28,7 +28,7 @@ import (
 	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	"github.com/blackducksoftware/horizon/pkg/components"
 	horizon "github.com/blackducksoftware/horizon/pkg/deployer"
-	"github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+	v1 "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
 	containers "github.com/blackducksoftware/synopsys-operator/pkg/apps/blackduck/v1/containers"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	log "github.com/sirupsen/logrus"

--- a/pkg/opssight/scanner.go
+++ b/pkg/opssight/scanner.go
@@ -275,7 +275,7 @@ func (p *SpecConfig) ScannerServiceAccount() *components.ServiceAccount {
 
 // ScannerClusterRoleBinding creates a cluster role binding for the perceptor scanner
 func (p *SpecConfig) ScannerClusterRoleBinding() (*components.ClusterRoleBinding, error) {
-	var clusterRole string
+	clusterRole := "synopsys-operator-admin"
 	var err error
 	if !p.config.DryRun {
 		clusterRole, err = util.GetOperatorClusterRole(p.kubeClient)

--- a/pkg/soperator/crdVersionMap.go
+++ b/pkg/soperator/crdVersionMap.go
@@ -68,6 +68,15 @@ type crdVersionData struct {
 	APIVersion string
 }
 
+// GetVersions returns a list of strings for the supported Operator Versions
+func (m *operatorCRDVersionMap) GetVersions() []string {
+	versions := []string{}
+	for v := range m.versionMap {
+		versions = append(versions, v)
+	}
+	return versions
+}
+
 // GetCRDVersions returns CRDVersionData for an Operator's Version. If the Operator's
 // version doesn't exist then it assumes master
 func (m *operatorCRDVersionMap) GetCRDVersions(operatorVersion string) operatorVersions {

--- a/pkg/soperator/soperator_components.go
+++ b/pkg/soperator/soperator_components.go
@@ -37,6 +37,7 @@ type SpecConfig struct {
 	Namespace                     string
 	Image                         string
 	Expose                        string
+	ClusterType                   ClusterType
 	OperatorTimeBombInSeconds     int64
 	DryRun                        bool
 	LogLevel                      string
@@ -46,20 +47,19 @@ type SpecConfig struct {
 	ResyncIntervalInSeconds       int64
 	TerminationGracePeriodSeconds int64
 	SealKey                       string
-	RestConfig                    *rest.Config
-	KubeClient                    *kubernetes.Clientset
 	Certificate                   string
 	CertificateKey                string
 }
 
 // NewSOperator will create a SOperator type
-func NewSOperator(namespace, synopsysOperatorImage, expose string, operatorTimeBombInSeconds int64, dryRun bool, logLevel string, threadiness int, postgresRestartInMins int64,
+func NewSOperator(namespace, synopsysOperatorImage, expose string, clusterType ClusterType, operatorTimeBombInSeconds int64, dryRun bool, logLevel string, threadiness int, postgresRestartInMins int64,
 	podWaitTimeoutSeconds int64, resyncIntervalInSeconds int64, terminationGracePeriodSeconds int64, sealKey string, restConfig *rest.Config,
 	kubeClient *kubernetes.Clientset, certificate string, certificateKey string) *SpecConfig {
 	return &SpecConfig{
 		Namespace:                     namespace,
 		Image:                         synopsysOperatorImage,
 		Expose:                        expose,
+		ClusterType:                   clusterType,
 		OperatorTimeBombInSeconds:     operatorTimeBombInSeconds,
 		DryRun:                        dryRun,
 		LogLevel:                      logLevel,
@@ -69,12 +69,19 @@ func NewSOperator(namespace, synopsysOperatorImage, expose string, operatorTimeB
 		ResyncIntervalInSeconds:       resyncIntervalInSeconds,
 		TerminationGracePeriodSeconds: terminationGracePeriodSeconds,
 		SealKey:                       sealKey,
-		RestConfig:                    restConfig,
-		KubeClient:                    kubeClient,
 		Certificate:                   certificate,
 		CertificateKey:                certificateKey,
 	}
 }
+
+// ClusterType represents the cluster type
+type ClusterType string
+
+// Constants for the PrintFormats
+const (
+	KubernetesClusterType ClusterType = "KUBERNETES"
+	OpenshiftClusterType  ClusterType = "OPENSHIFT"
+)
 
 // GetComponents will return a ComponentList representing all
 // Kubernetes Resources for Synopsys Operator

--- a/pkg/soperator/soperator_resources.go
+++ b/pkg/soperator/soperator_resources.go
@@ -39,10 +39,9 @@ func (specConfig *SpecConfig) GetOperatorDeployment() (*horizoncomponents.Deploy
 	// Add the Replication Controller to the Deployer
 	var synopsysOperatorReplicas int32 = 1
 	synopsysOperator := horizoncomponents.NewDeployment(horizonapi.DeploymentConfig{
-		APIVersion: "v1",
-		Name:       "synopsys-operator",
-		Namespace:  specConfig.Namespace,
-		Replicas:   &synopsysOperatorReplicas,
+		Name:      "synopsys-operator",
+		Namespace: specConfig.Namespace,
+		Replicas:  &synopsysOperatorReplicas,
 	})
 
 	synopsysOperator.AddMatchLabelsSelectors(map[string]string{"app": "synopsys-operator", "component": "operator"})
@@ -231,17 +230,18 @@ func (specConfig *SpecConfig) GetOperatorConfigMap() (*horizoncomponents.ConfigM
 
 	cmData := map[string]string{}
 	configData := map[string]interface{}{
+		"Namespace":                     specConfig.Namespace,
+		"Image":                         specConfig.Image,
+		"Expose":                        specConfig.Expose,
+		"ClusterType":                   specConfig.ClusterType,
 		"OperatorTimeBombInSeconds":     specConfig.OperatorTimeBombInSeconds,
 		"DryRun":                        specConfig.DryRun,
 		"LogLevel":                      specConfig.LogLevel,
-		"Namespace":                     specConfig.Namespace,
 		"Threadiness":                   specConfig.Threadiness,
 		"PostgresRestartInMins":         specConfig.PostgresRestartInMins,
 		"PodWaitTimeoutSeconds":         specConfig.PodWaitTimeoutSeconds,
 		"ResyncIntervalInSeconds":       specConfig.ResyncIntervalInSeconds,
 		"TerminationGracePeriodSeconds": specConfig.TerminationGracePeriodSeconds,
-		"Image":                         specConfig.Image,
-		"Expose":                        specConfig.Expose,
 	}
 	bytes, err := json.Marshal(configData)
 	if err != nil {
@@ -372,8 +372,7 @@ func (specConfig *SpecConfig) GetOperatorClusterRole() *horizoncomponents.Cluste
 	})
 
 	// Add Openshift rules
-	routeClient := util.GetRouteClient(specConfig.RestConfig) // kube doesn't have a routeclient
-	if routeClient != nil {                                   // openshift: has a routeClient
+	if specConfig.ClusterType == OpenshiftClusterType {
 		synopsysOperatorClusterRole.AddPolicyRule(horizonapi.PolicyRuleConfig{
 			Verbs:           []string{"get", "update", "patch"},
 			APIGroups:       []string{"security.openshift.io"},

--- a/pkg/synopsysctl/CRDPrint.go
+++ b/pkg/synopsysctl/CRDPrint.go
@@ -1,0 +1,145 @@
+/*
+Copyright (C) 2019 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package synopsysctl
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/yaml"
+
+	alertapi "github.com/blackducksoftware/synopsys-operator/pkg/api/alert/v1"
+	blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+	opssightapi "github.com/blackducksoftware/synopsys-operator/pkg/api/opssight/v1"
+	"github.com/blackducksoftware/synopsys-operator/pkg/apps"
+	"github.com/blackducksoftware/synopsys-operator/pkg/opssight"
+	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
+	"github.com/blackducksoftware/synopsys-operator/pkg/soperator"
+)
+
+// PrintFormat represents the format to print the struct
+type PrintFormat string
+
+// Constants for the PrintFormats
+const (
+	JSON PrintFormat = "JSON"
+	YAML PrintFormat = "YAML"
+)
+
+// PrintResource prints a Resource as yaml or json. printKubeComponents allows printing the kuberentes
+// resources instead
+func PrintResource(crd interface{}, format string, printKubeComponents bool) error {
+	// print the CRD
+	if !printKubeComponents {
+		return PrintComponents([]interface{}{crd}, format)
+	}
+
+	// print the Kube Components
+	var kubeInterfaces []interface{}
+
+	pc := &protoform.Config{}
+	pc.SelfSetDefaults()
+	pc.DryRun = true
+	rc := &rest.Config{}
+	app := apps.NewApp(pc, rc)
+
+	switch reflect.TypeOf(crd) {
+	case reflect.TypeOf(soperator.SpecConfig{}):
+		operator := crd.(soperator.SpecConfig)
+		cList, err := operator.GetComponents()
+		if err != nil {
+			return fmt.Errorf("failed to get components: %s", err)
+		}
+		kubeInterfaces = cList.GetKubeInterfaces()
+	case reflect.TypeOf(alertapi.Alert{}):
+		alert := crd.(alertapi.Alert)
+		cList, err := app.Alert().GetComponents(&alert)
+		if err != nil {
+			return fmt.Errorf("failed to get components: %s", err)
+		}
+		kubeInterfaces = cList.GetKubeInterfaces()
+	case reflect.TypeOf(blackduckapi.Blackduck{}):
+		blackDuck := crd.(blackduckapi.Blackduck)
+		cList, err := app.Blackduck().GetComponents(&blackDuck)
+		if err != nil {
+			return fmt.Errorf("failed to get components: %s", err)
+		}
+		kubeInterfaces = cList.GetKubeInterfaces()
+	case reflect.TypeOf(opssightapi.OpsSight{}):
+		opsSight := crd.(opssightapi.OpsSight)
+		sc := opssight.NewSpecConfig(pc, kubeClient, opsSightClient, blackDuckClient, &opsSight, true)
+		cList, err := sc.GetComponents()
+		if err != nil {
+			return fmt.Errorf("failed to get components: %s", err)
+		}
+		kubeInterfaces = cList.GetKubeInterfaces()
+	default:
+		return fmt.Errorf("crd is not supported for printing")
+	}
+
+	err := PrintComponents(kubeInterfaces, format)
+	if err != nil {
+		return fmt.Errorf("failed to print components: %s", err)
+	}
+
+	return nil
+}
+
+// PrintComponents outputs components for a CRD in the correct format for 'kubectl create -f <file>'
+func PrintComponents(objs []interface{}, format string) error {
+	for i, obj := range objs {
+		_, err := PrintComponent(obj, format)
+		if err != nil {
+			return fmt.Errorf("failed to print in mock mode: %s", err)
+		}
+		if i != len(objs)-1 && format == "yaml" {
+			fmt.Printf("---\n")
+		}
+	}
+	return nil
+}
+
+// PrintComponent will print the interface in either json or yaml format
+func PrintComponent(v interface{}, format string) (string, error) {
+	var b []byte
+	var err error
+	switch {
+	case strings.ToUpper(format) == string(JSON):
+		b, err = json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("failed to convert struct to json. Err: %+v. Struct: %+v", err, v)
+		}
+		fmt.Println(string(b))
+	case strings.ToUpper(format) == string(YAML):
+		b, err = yaml.Marshal(v)
+		if err != nil {
+			return "", fmt.Errorf("failed to convert struct to yaml. Err: %+v. Struct: %+v", err, v)
+		}
+		fmt.Println(string(b))
+	default:
+		return "", fmt.Errorf("%s is an invalid format for PrettyPrint", format)
+	}
+	return string(b), nil
+}

--- a/pkg/synopsysctl/cmd_destroy.go
+++ b/pkg/synopsysctl/cmd_destroy.go
@@ -24,15 +24,11 @@ package synopsysctl
 import (
 	"fmt"
 
-	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 )
-
-// Deploy Command Global Variables
-var secretType horizonapi.SecretType
 
 // destroyCmd removes Synopsys Operator from the cluster
 var destroyCmd = &cobra.Command{

--- a/pkg/synopsysctl/cmd_root.go
+++ b/pkg/synopsysctl/cmd_root.go
@@ -80,9 +80,9 @@ func Execute() {
 func init() {
 	//(PassCmd) rootCmd.DisableFlagParsing = true // lets rootCmd pass flags to kube/oc
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", kubeconfig, "path to the kubeconfig file to use for CLI requests")
-	rootCmd.PersistentFlags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "server's certificate won't be validated. HTTPS will be less secure")
-	rootCmd.PersistentFlags().StringVarP(&logLevelCtl, "verbose-level", "v", logLevelCtl, "log level for the synopsysctl [trace|debug|info|warn|error|fatal|panic]")
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", kubeconfig, "Path to the kubeconfig file to use for CLI requests")
+	rootCmd.PersistentFlags().BoolVar(&insecureSkipTLSVerify, "insecure-skip-tls-verify", insecureSkipTLSVerify, "Server's certificate won't be validated. HTTPS will be less secure")
+	rootCmd.PersistentFlags().StringVarP(&logLevelCtl, "verbose-level", "v", logLevelCtl, "Log level for the synopsysctl [trace|debug|info|warn|error|fatal|panic]")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/util/prettyprint.go
+++ b/pkg/util/prettyprint.go
@@ -24,38 +24,16 @@ package util
 import (
 	"encoding/json"
 	"fmt"
-
-	yaml "gopkg.in/yaml.v2"
-)
-
-// PrintFormat represents the format to print the struct
-type PrintFormat string
-
-// Constants for the PrintFormats
-const (
-	JSON PrintFormat = "json"
-	YAML PrintFormat = "yaml"
 )
 
 // PrettyPrint will print the interface in string format
-func PrettyPrint(v interface{}, format string) (string, error) {
+func PrettyPrint(v interface{}) (string, error) {
 	var b []byte
 	var err error
-	switch {
-	case format == string(JSON):
-		b, err = json.MarshalIndent(v, "", "  ")
-		if err != nil {
-			return "", fmt.Errorf("Failed to convert struct to yaml. Struct: %+v", v)
-		}
-		fmt.Println(string(b))
-	case format == string(YAML):
-		b, err = yaml.Marshal(v)
-		if err != nil {
-			return "", fmt.Errorf("Failed to convert struct to yaml. Struct: %+v", v)
-		}
-		fmt.Println(string(b))
-	default:
-		return "", fmt.Errorf("%s is an invalid format for PrettyPrint", format)
+	b, err = json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to convert struct to json. Struct: %+v", v)
 	}
+	fmt.Println(string(b))
 	return string(b), nil
 }


### PR DESCRIPTION
Ability to print the Spec or Kubernetes-Resources for Commands Deploy, Create, and Update. Yaml and Json formats are supported. The Resource-Specs and Kubernetes-Resources can be piped into a file and created with `kubectl create -f <file>`. 