### PR TITLE
Edit bash commands to use && where applicable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,28 +24,28 @@ PLATFORM := darwin linux windows
 
 binary: clean ${OUTDIR} 
 	$(foreach p,${PLATFORM}, \
-		echo "creating synopsysctl binary for $(p) platform"; \
+		echo "creating synopsysctl binary for $(p) platform" && \
 		if [[ $(p) = ${WINDOWS} ]]; then \
 			docker run --rm -e CGO_ENABLED=0 -e GOOS=$(p) -e GOARCH=amd64 -e GO111MODULE=on -v "${CURRENT_DIR}":/go/src/github.com/blackducksoftware/synopsys-operator -w /go/src/github.com/blackducksoftware/synopsys-operator/cmd/synopsysctl golang:1.12 go build -o /go/src/github.com/blackducksoftware/synopsys-operator/${OUTDIR}/$(p)/synopsysctl.exe; \
 		else \
 			docker run --rm -e CGO_ENABLED=0 -e GOOS=$(p) -e GOARCH=amd64 -e GO111MODULE=on -v "${CURRENT_DIR}":/go/src/github.com/blackducksoftware/synopsys-operator -w /go/src/github.com/blackducksoftware/synopsys-operator/cmd/synopsysctl golang:1.12 go build -o /go/src/github.com/blackducksoftware/synopsys-operator/${OUTDIR}/$(p)/synopsysctl; \
-		fi; \
-		echo "completed synopsysctl binary for $(p) platform"; \
+		fi && \
+		echo "completed synopsysctl binary for $(p) platform" \
 	)
 
 package:
 	$(foreach p,${PLATFORM}, \
-		echo "creating synopsysctl package for $(p) platform"; \
-		cd ${OUTDIR}/$(p); \
+		echo "creating synopsysctl package for $(p) platform" && \
+		cd ${OUTDIR}/$(p) && \
 		if [[ $(p) = ${LINUX} ]]; then \
 			tar -zcvf synopsysctl-$(p)-amd64.tar.gz synopsysctl && mv synopsysctl-$(p)-amd64.tar.gz .. && cd .. && $(SHA_SUM_CMD) synopsysctl-$(p)-amd64.tar.gz >> CHECKSUM && rm -rf $(p); \
 		elif [[ $(p) = ${WINDOWS} ]]; then \
 			zip synopsysctl-$(p)-amd64.zip synopsysctl.exe && mv synopsysctl-$(p)-amd64.zip .. && cd .. && $(SHA_SUM_CMD) synopsysctl-$(p)-amd64.zip >> CHECKSUM && rm -rf $(p); \
 		else \
 			zip synopsysctl-$(p)-amd64.zip synopsysctl && mv synopsysctl-$(p)-amd64.zip .. && cd .. && $(SHA_SUM_CMD) synopsysctl-$(p)-amd64.zip >> CHECKSUM && rm -rf $(p); \
-		fi; \
-		echo "completed synopsysctl package for $(p) platform"; \
-		cd ..; \
+		fi && \
+		echo "completed synopsysctl package for $(p) platform" && \
+		cd .. \
 	)
 
 clean:
@@ -54,7 +54,7 @@ clean:
 ${OUTDIR}:
 	mkdir -p ${OUTDIR}
 	$(foreach p,${PLATFORM}, \
-		mkdir -p ${OUTDIR}/$(p); \
+		mkdir -p ${OUTDIR}/$(p) \
 	)
 
 init:


### PR DESCRIPTION
I noticed one of the builds had the following error message in the log when running make binary:
```
go: golang.org/x/sync@v0.0.0-20181108010431-42b317875d0f: git -c protocol.version=0 fetch --unshallow -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /go/pkg/mod/cache/vcs/55179c5d8c4db2eaed9fae4682d4c84a1fd3612df666b372bef3bbb997c9601f: exit status 128:
fatal: unable to access 'https://go.googlesource.com/sync/': Failed to connect to go.googlesource.com port 443: No route to host
```
But, the build continued and actually failed on a different step when it should have exited non-zero when the make binary command finished.

This PR is to adjust some of the commands in the Makefile to change ; with &&. Using ; between bash commands will ignore the status of the previous command and continue on. Using && will stop execution if the previous command fails.

To run a quick test, against a clean workspace, running make binary displays error messages as it tries to run the package command for all platforms, and exits with a zero status. Running with the edits in this PR displays the error messages for the 1st platform and exits with a non-zero status.