### PR TITLE
fixed issue setting blackudck pvc sizes

### DIFF
--- a/pkg/apps/blackduck/latest/containers/pvc_test.go
+++ b/pkg/apps/blackduck/latest/containers/pvc_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright (C) 2019 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package containers
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	horizoncomponents "github.com/blackducksoftware/horizon/pkg/components"
+	blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetPVCs(t *testing.T) {
+	// Default protoform Config in DryRun mode for this test
+	pc := protoform.Config{}
+	pc.SelfSetDefaults()
+	pc.DryRun = true
+	// Black Duck flavor for this test
+	flavor := GetContainersFlavor("small")
+	// Binary Analysis state for this test
+	ba := false
+	// Default PVCs for this test
+	c := NewCreater(&pc, nil, &blackduckapi.BlackduckSpec{PersistentStorage: true}, flavor, ba)
+	defaultPVCs := c.GetPVCs()
+
+	// Case: No PVCs specified - defaults
+	specPVCs := []blackduckapi.PVC{}
+	blackDuckSpec := blackduckapi.BlackduckSpec{
+		PersistentStorage: true,
+		PVC:               specPVCs,
+	}
+	c = NewCreater(&pc, nil, &blackDuckSpec, flavor, ba)
+	createdPVCs := c.GetPVCs()
+	err := checkPVCs(defaultPVCs, specPVCs, createdPVCs)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	// Case: PVC name and storage class are changed
+	specPVCs = []blackduckapi.PVC{
+		{
+			Name:         defaultPVCs[0].GetName(),
+			Size:         "10Gi",
+			StorageClass: "testStorageClass",
+		},
+	}
+	blackDuckSpec = blackduckapi.BlackduckSpec{
+		PersistentStorage: true,
+		PVCStorageClass:   "globalStorageClass",
+		PVC:               specPVCs,
+	}
+	c = NewCreater(&pc, nil, &blackDuckSpec, flavor, ba)
+	createdPVCs = c.GetPVCs()
+	err = checkPVCs(defaultPVCs, specPVCs, createdPVCs)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	// Case: Invalid PVC Name isn't added
+	specPVCs = []blackduckapi.PVC{
+		{
+			Name:         "badName",
+			Size:         "10Gi",
+			StorageClass: "testStorageClass",
+		},
+	}
+	blackDuckSpec = blackduckapi.BlackduckSpec{
+		PersistentStorage: true,
+		PVCStorageClass:   "globalStorageClass",
+		PVC:               specPVCs,
+	}
+	c = NewCreater(&pc, nil, &blackDuckSpec, flavor, ba)
+	createdPVCs = c.GetPVCs()
+	err = checkPVCs(defaultPVCs, []blackduckapi.PVC{}, createdPVCs) // a bad PVC is like it doesn't exist
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	// Case: Bad PVC is ignored and Good PVC is added
+	specPVCs = []blackduckapi.PVC{
+		{
+			Name:         defaultPVCs[0].GetName(),
+			Size:         "10Gi",
+			StorageClass: "testStorageClass",
+		},
+		{
+			Name:         "badName",
+			Size:         "10Gi",
+			StorageClass: "testStorageClass",
+		},
+	}
+	blackDuckSpec = blackduckapi.BlackduckSpec{
+		PersistentStorage: true,
+		PVCStorageClass:   "globalStorageClass",
+		PVC:               specPVCs,
+	}
+	c = NewCreater(&pc, nil, &blackDuckSpec, flavor, ba)
+	createdPVCs = c.GetPVCs()
+	err = checkPVCs(defaultPVCs, []blackduckapi.PVC{{Name: defaultPVCs[0].GetName(), Size: "10Gi", StorageClass: "testStorageClass"}}, createdPVCs)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
+func checkPVCs(defaultPVCs []*horizoncomponents.PersistentVolumeClaim, expectedPVCs []blackduckapi.PVC, observedPVCs []*horizoncomponents.PersistentVolumeClaim) error {
+	// Create PVC mappings
+	defaultPVCMap := make(map[string]*horizoncomponents.PersistentVolumeClaim)
+	for _, claim := range defaultPVCs {
+		defaultPVCMap[claim.GetName()] = claim
+	}
+
+	expectedPVCMap := make(map[string]blackduckapi.PVC)
+	for _, claim := range expectedPVCs {
+		expectedPVCMap[claim.Name] = claim
+	}
+
+	observedPVCMap := make(map[string]*horizoncomponents.PersistentVolumeClaim)
+	for _, claim := range observedPVCs {
+		observedPVCMap[claim.GetName()] = claim
+	}
+
+	// Check the number of observed PVCs is the same as default PVCs
+	if len(defaultPVCs) != len(observedPVCs) {
+		return fmt.Errorf("invalid number of PVCs - expected %+v, got %+v", len(defaultPVCs), len(observedPVCs))
+	}
+
+	// Check the observed PVCs have correct default PVC names
+	for observedPVCName := range observedPVCMap {
+		if _, exists := defaultPVCMap[observedPVCName]; !exists {
+			return fmt.Errorf("created PVC %+v is not in the default PVCs for Black Duck", observedPVCName)
+		}
+	}
+
+	// Check the expected PVC names are in the observed PVC names
+	for expectedPVCName := range expectedPVCMap {
+		if _, exists := observedPVCMap[expectedPVCName]; !exists {
+			return fmt.Errorf("expected PVC %+v is not in the created PVCs", expectedPVCName)
+		}
+	}
+
+	// Check the expected PVC values are correctly set in observed PVCs
+	for expectedPVCName, expectedPVC := range expectedPVCMap {
+		observedPVCObj := observedPVCMap[expectedPVCName].PersistentVolumeClaim
+		defaultPVCObj := defaultPVCMap[expectedPVCName].PersistentVolumeClaim
+		if len(expectedPVC.Size) > 0 { // use the specified size
+			observedSize := observedPVCObj.Spec.Resources.Requests[v1.ResourceStorage]
+			expectedSize, _ := resource.ParseQuantity(expectedPVC.Size)
+			if expectedSize != observedSize {
+				return fmt.Errorf("invalid set storage size - expected %+v, got %+v", expectedSize, observedSize)
+			}
+		} else { // use the default size
+			observedSize := observedPVCObj.Spec.Resources.Requests[v1.ResourceStorage]
+			defaultSize := defaultPVCObj.Spec.Resources.Requests[v1.ResourceStorage]
+			if observedSize != defaultSize {
+				return fmt.Errorf("invalid default storage size - expected %+v, got %+v", defaultSize, observedSize)
+			}
+		}
+		if len(expectedPVC.StorageClass) > 0 {
+			if expectedPVC.StorageClass != *observedPVCObj.Spec.StorageClassName {
+				return fmt.Errorf("invalid storageClass - expected %+v, got %+v", expectedPVC.StorageClass, *observedPVCObj.Spec.StorageClassName)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/apps/blackduck/v1/containers/pvc.go
+++ b/pkg/apps/blackduck/v1/containers/pvc.go
@@ -22,10 +22,9 @@ under the License.
 package containers
 
 import (
-	"strings"
-
 	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	"github.com/blackducksoftware/horizon/pkg/components"
+	blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -58,21 +57,24 @@ func (c *Creater) GetPVCs() []*components.PersistentVolumeClaim {
 	}
 
 	if c.hubSpec.PersistentStorage {
-		for k, v := range defaultPVC {
-			size := v
-			storageClass := ""
-			for _, claim := range c.hubSpec.PVC {
-				if strings.EqualFold(claim.Name, k) {
-					if len(claim.StorageClass) > 0 {
-						storageClass = claim.StorageClass
-					}
-					if len(claim.Size) > 0 {
-						size = claim.StorageClass
-					}
+		pvcMap := make(map[string]blackduckapi.PVC)
+		for _, claim := range c.hubSpec.PVC {
+			pvcMap[claim.Name] = claim
+		}
+
+		for name, defaultSize := range defaultPVC {
+			size := defaultSize
+			storageClass := c.hubSpec.PVCStorageClass
+			if claim, ok := pvcMap[name]; ok {
+				if len(claim.StorageClass) > 0 {
+					storageClass = claim.StorageClass
 				}
-				break
+				if len(claim.Size) > 0 {
+					size = claim.Size
+				}
 			}
-			pvcs = append(pvcs, c.createPVC(k, size, v, storageClass, horizonapi.ReadWriteOnce, c.GetLabel("pvc")))
+
+			pvcs = append(pvcs, c.createPVC(name, size, defaultSize, storageClass, horizonapi.ReadWriteOnce, c.GetLabel("pvc")))
 		}
 	}
 
@@ -84,8 +86,6 @@ func (c *Creater) createPVC(name string, requestedSize string, defaultSize strin
 	var class *string
 	if len(storageclass) > 0 {
 		class = &storageclass
-	} else if len(c.hubSpec.PVCStorageClass) > 0 {
-		class = &c.hubSpec.PVCStorageClass
 	} else {
 		class = nil
 	}

--- a/pkg/apps/blackduck/v1/containers/pvc_test.go
+++ b/pkg/apps/blackduck/v1/containers/pvc_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright (C) 2019 Synopsys, Inc.
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+
+package containers
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	horizoncomponents "github.com/blackducksoftware/horizon/pkg/components"
+	blackduckapi "github.com/blackducksoftware/synopsys-operator/pkg/api/blackduck/v1"
+	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestGetPVCs(t *testing.T) {
+	// Default protoform Config in DryRun mode for this test
+	pc := protoform.Config{}
+	pc.SelfSetDefaults()
+	pc.DryRun = true
+	// Black Duck flavor for this test
+	flavor := GetContainersFlavor("small")
+	// Binary Analysis state for this test
+	ba := false
+	// Default PVCs for this test
+	c := NewCreater(&pc, nil, &blackduckapi.BlackduckSpec{PersistentStorage: true}, flavor, ba)
+	defaultPVCs := c.GetPVCs()
+
+	// Case: No PVCs specified - defaults
+	specPVCs := []blackduckapi.PVC{}
+	blackDuckSpec := blackduckapi.BlackduckSpec{
+		PersistentStorage: true,
+		PVC:               specPVCs,
+	}
+	c = NewCreater(&pc, nil, &blackDuckSpec, flavor, ba)
+	createdPVCs := c.GetPVCs()
+	err := checkPVCs(defaultPVCs, specPVCs, createdPVCs)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	// Case: PVC name and storage class are changed
+	specPVCs = []blackduckapi.PVC{
+		{
+			Name:         defaultPVCs[0].GetName(),
+			Size:         "10Gi",
+			StorageClass: "testStorageClass",
+		},
+	}
+	blackDuckSpec = blackduckapi.BlackduckSpec{
+		PersistentStorage: true,
+		PVCStorageClass:   "globalStorageClass",
+		PVC:               specPVCs,
+	}
+	c = NewCreater(&pc, nil, &blackDuckSpec, flavor, ba)
+	createdPVCs = c.GetPVCs()
+	err = checkPVCs(defaultPVCs, specPVCs, createdPVCs)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	// Case: Invalid PVC Name isn't added
+	specPVCs = []blackduckapi.PVC{
+		{
+			Name:         "badName",
+			Size:         "10Gi",
+			StorageClass: "testStorageClass",
+		},
+	}
+	blackDuckSpec = blackduckapi.BlackduckSpec{
+		PersistentStorage: true,
+		PVCStorageClass:   "globalStorageClass",
+		PVC:               specPVCs,
+	}
+	c = NewCreater(&pc, nil, &blackDuckSpec, flavor, ba)
+	createdPVCs = c.GetPVCs()
+	err = checkPVCs(defaultPVCs, []blackduckapi.PVC{}, createdPVCs) // a bad PVC is like it doesn't exist
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	// Case: Bad PVC is ignored and Good PVC is added
+	specPVCs = []blackduckapi.PVC{
+		{
+			Name:         defaultPVCs[0].GetName(),
+			Size:         "10Gi",
+			StorageClass: "testStorageClass",
+		},
+		{
+			Name:         "badName",
+			Size:         "10Gi",
+			StorageClass: "testStorageClass",
+		},
+	}
+	blackDuckSpec = blackduckapi.BlackduckSpec{
+		PersistentStorage: true,
+		PVCStorageClass:   "globalStorageClass",
+		PVC:               specPVCs,
+	}
+	c = NewCreater(&pc, nil, &blackDuckSpec, flavor, ba)
+	createdPVCs = c.GetPVCs()
+	err = checkPVCs(defaultPVCs, []blackduckapi.PVC{{Name: defaultPVCs[0].GetName(), Size: "10Gi", StorageClass: "testStorageClass"}}, createdPVCs)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+}
+
+func checkPVCs(defaultPVCs []*horizoncomponents.PersistentVolumeClaim, expectedPVCs []blackduckapi.PVC, observedPVCs []*horizoncomponents.PersistentVolumeClaim) error {
+	// Create PVC mappings
+	defaultPVCMap := make(map[string]*horizoncomponents.PersistentVolumeClaim)
+	for _, claim := range defaultPVCs {
+		defaultPVCMap[claim.GetName()] = claim
+	}
+
+	expectedPVCMap := make(map[string]blackduckapi.PVC)
+	for _, claim := range expectedPVCs {
+		expectedPVCMap[claim.Name] = claim
+	}
+
+	observedPVCMap := make(map[string]*horizoncomponents.PersistentVolumeClaim)
+	for _, claim := range observedPVCs {
+		observedPVCMap[claim.GetName()] = claim
+	}
+
+	// Check the number of observed PVCs is the same as default PVCs
+	if len(defaultPVCs) != len(observedPVCs) {
+		return fmt.Errorf("invalid number of PVCs - expected %+v, got %+v", len(defaultPVCs), len(observedPVCs))
+	}
+
+	// Check the observed PVCs have correct default PVC names
+	for observedPVCName := range observedPVCMap {
+		if _, exists := defaultPVCMap[observedPVCName]; !exists {
+			return fmt.Errorf("created PVC %+v is not in the default PVCs for Black Duck", observedPVCName)
+		}
+	}
+
+	// Check the expected PVC names are in the observed PVC names
+	for expectedPVCName := range expectedPVCMap {
+		if _, exists := observedPVCMap[expectedPVCName]; !exists {
+			return fmt.Errorf("expected PVC %+v is not in the created PVCs", expectedPVCName)
+		}
+	}
+
+	// Check the expected PVC values are correctly set in observed PVCs
+	for expectedPVCName, expectedPVC := range expectedPVCMap {
+		observedPVCObj := observedPVCMap[expectedPVCName].PersistentVolumeClaim
+		defaultPVCObj := defaultPVCMap[expectedPVCName].PersistentVolumeClaim
+		if len(expectedPVC.Size) > 0 { // use the specified size
+			observedSize := observedPVCObj.Spec.Resources.Requests[v1.ResourceStorage]
+			expectedSize, _ := resource.ParseQuantity(expectedPVC.Size)
+			if expectedSize != observedSize {
+				return fmt.Errorf("invalid set storage size - expected %+v, got %+v", expectedSize, observedSize)
+			}
+		} else { // use the default size
+			observedSize := observedPVCObj.Spec.Resources.Requests[v1.ResourceStorage]
+			defaultSize := defaultPVCObj.Spec.Resources.Requests[v1.ResourceStorage]
+			if observedSize != defaultSize {
+				return fmt.Errorf("invalid default storage size - expected %+v, got %+v", defaultSize, observedSize)
+			}
+		}
+		if len(expectedPVC.StorageClass) > 0 {
+			if expectedPVC.StorageClass != *observedPVCObj.Spec.StorageClassName {
+				return fmt.Errorf("invalid storageClass - expected %+v, got %+v", expectedPVC.StorageClass, *observedPVCObj.Spec.StorageClassName)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The Synopsys Operator overwrites default PVC size values with the user's input in the spec for Black Duck. Test files verify that this is done correctly. 