### PR TITLE
fix password used by postgres user

### DIFF
--- a/pkg/apps/blackduck/latest/containers/postgres.go
+++ b/pkg/apps/blackduck/latest/containers/postgres.go
@@ -52,8 +52,8 @@ func (c *Creater) GetPostgres() *postgres.Postgres {
 		Database:               "blackduck",
 		User:                   "blackduck",
 		PasswordSecretName:     "db-creds",
-		UserPasswordSecretKey:  "HUB_POSTGRES_USER_PASSWORD_FILE",
-		AdminPasswordSecretKey: "HUB_POSTGRES_ADMIN_PASSWORD_FILE",
+		UserPasswordSecretKey:  "HUB_POSTGRES_ADMIN_PASSWORD_FILE",
+		AdminPasswordSecretKey: "HUB_POSTGRES_POSTGRES_PASSWORD_FILE",
 		MaxConnections:         300,
 		SharedBufferInMB:       1024,
 		EnvConfigMapRefs:       []string{"blackduck-db-config"},
@@ -95,13 +95,13 @@ func (c *Creater) GetPostgresConfigmap() *components.ConfigMap {
 }
 
 // GetPostgresSecret will return the postgres secret
-func (c *Creater) GetPostgresSecret(adminPassword string, userPassword string) *components.Secret {
+func (c *Creater) GetPostgresSecret(adminPassword string, userPassword string, postgresPassword string) *components.Secret {
 	hubSecret := components.NewSecret(horizonapi.SecretConfig{Namespace: c.hubSpec.Namespace, Name: "db-creds", Type: horizonapi.SecretTypeOpaque})
 
 	if c.hubSpec.ExternalPostgres != nil {
 		hubSecret.AddData(map[string][]byte{"HUB_POSTGRES_ADMIN_PASSWORD_FILE": []byte(c.hubSpec.ExternalPostgres.PostgresAdminPassword), "HUB_POSTGRES_USER_PASSWORD_FILE": []byte(c.hubSpec.ExternalPostgres.PostgresUserPassword)})
 	} else {
-		hubSecret.AddData(map[string][]byte{"HUB_POSTGRES_ADMIN_PASSWORD_FILE": []byte(adminPassword), "HUB_POSTGRES_USER_PASSWORD_FILE": []byte(userPassword)})
+		hubSecret.AddData(map[string][]byte{"HUB_POSTGRES_ADMIN_PASSWORD_FILE": []byte(adminPassword), "HUB_POSTGRES_USER_PASSWORD_FILE": []byte(userPassword), "HUB_POSTGRES_POSTGRES_PASSWORD_FILE": []byte(postgresPassword)})
 	}
 	hubSecret.AddLabels(c.GetVersionLabel("postgres"))
 

--- a/pkg/apps/blackduck/latest/deployer.go
+++ b/pkg/apps/blackduck/latest/deployer.go
@@ -48,7 +48,7 @@ func (hc *Creater) getPostgresComponents(blackduck *blackduckapi.Blackduck) (*ap
 
 	containerCreater := containers.NewCreater(hc.Config, hc.KubeClient, &blackduck.Spec, hubContainerFlavor, false)
 	// Get Db creds
-	var adminPassword, userPassword string
+	var adminPassword, userPassword, postgresPassword string
 	if blackduck.Spec.ExternalPostgres != nil {
 
 		adminPassword, err = util.Base64Decode(blackduck.Spec.ExternalPostgres.PostgresAdminPassword)
@@ -73,6 +73,11 @@ func (hc *Creater) getPostgresComponents(blackduck *blackduckapi.Blackduck) (*ap
 			return nil, fmt.Errorf("%v: unable to decode userPassword due to: %+v", blackduck.Spec.Namespace, err)
 		}
 
+		postgresPassword, err = util.Base64Decode(blackduck.Spec.PostgresPassword)
+		if err != nil {
+			return nil, fmt.Errorf("%v: unable to decode postgresPassword due to: %+v", blackduck.Spec.Namespace, err)
+		}
+
 	}
 
 	postgres := containerCreater.GetPostgres()
@@ -85,7 +90,7 @@ func (hc *Creater) getPostgresComponents(blackduck *blackduckapi.Blackduck) (*ap
 		componentList.Services = append(componentList.Services, postgres.GetPostgresService())
 	}
 	componentList.ConfigMaps = append(componentList.ConfigMaps, containerCreater.GetPostgresConfigmap())
-	componentList.Secrets = append(componentList.Secrets, containerCreater.GetPostgresSecret(adminPassword, userPassword))
+	componentList.Secrets = append(componentList.Secrets, containerCreater.GetPostgresSecret(adminPassword, userPassword, postgresPassword))
 
 	return componentList, nil
 }

--- a/pkg/apps/blackduck/v1/containers/postgres.go
+++ b/pkg/apps/blackduck/v1/containers/postgres.go
@@ -52,8 +52,8 @@ func (c *Creater) GetPostgres() *postgres.Postgres {
 		Database:               "blackduck",
 		User:                   "blackduck",
 		PasswordSecretName:     "db-creds",
-		UserPasswordSecretKey:  "HUB_POSTGRES_USER_PASSWORD_FILE",
-		AdminPasswordSecretKey: "HUB_POSTGRES_ADMIN_PASSWORD_FILE",
+		UserPasswordSecretKey:  "HUB_POSTGRES_ADMIN_PASSWORD_FILE",
+		AdminPasswordSecretKey: "HUB_POSTGRES_POSTGRES_PASSWORD_FILE",
 		MaxConnections:         300,
 		SharedBufferInMB:       1024,
 		EnvConfigMapRefs:       []string{"blackduck-db-config"},
@@ -95,13 +95,13 @@ func (c *Creater) GetPostgresConfigmap() *components.ConfigMap {
 }
 
 // GetPostgresSecret will return the postgres secret
-func (c *Creater) GetPostgresSecret(adminPassword string, userPassword string) *components.Secret {
+func (c *Creater) GetPostgresSecret(adminPassword string, userPassword string, postgresPassword string) *components.Secret {
 	hubSecret := components.NewSecret(horizonapi.SecretConfig{Namespace: c.hubSpec.Namespace, Name: "db-creds", Type: horizonapi.SecretTypeOpaque})
 
 	if c.hubSpec.ExternalPostgres != nil {
 		hubSecret.AddData(map[string][]byte{"HUB_POSTGRES_ADMIN_PASSWORD_FILE": []byte(c.hubSpec.ExternalPostgres.PostgresAdminPassword), "HUB_POSTGRES_USER_PASSWORD_FILE": []byte(c.hubSpec.ExternalPostgres.PostgresUserPassword)})
 	} else {
-		hubSecret.AddData(map[string][]byte{"HUB_POSTGRES_ADMIN_PASSWORD_FILE": []byte(adminPassword), "HUB_POSTGRES_USER_PASSWORD_FILE": []byte(userPassword)})
+		hubSecret.AddData(map[string][]byte{"HUB_POSTGRES_ADMIN_PASSWORD_FILE": []byte(adminPassword), "HUB_POSTGRES_USER_PASSWORD_FILE": []byte(userPassword), "HUB_POSTGRES_POSTGRES_PASSWORD_FILE": []byte(postgresPassword)})
 	}
 	hubSecret.AddLabels(c.GetVersionLabel("postgres"))
 

--- a/pkg/apps/blackduck/v1/deployer.go
+++ b/pkg/apps/blackduck/v1/deployer.go
@@ -48,7 +48,7 @@ func (hc *Creater) getPostgresComponents(blackduck *blackduckapi.Blackduck) (*ap
 
 	containerCreater := containers.NewCreater(hc.Config, hc.KubeClient, &blackduck.Spec, hubContainerFlavor, false)
 	// Get Db creds
-	var adminPassword, userPassword string
+	var adminPassword, userPassword, postgresPassword string
 	if blackduck.Spec.ExternalPostgres != nil {
 
 		adminPassword, err = util.Base64Decode(blackduck.Spec.ExternalPostgres.PostgresAdminPassword)
@@ -73,6 +73,11 @@ func (hc *Creater) getPostgresComponents(blackduck *blackduckapi.Blackduck) (*ap
 			return nil, fmt.Errorf("%v: unable to decode userPassword due to: %+v", blackduck.Spec.Namespace, err)
 		}
 
+		postgresPassword, err = util.Base64Decode(blackduck.Spec.PostgresPassword)
+		if err != nil {
+			return nil, fmt.Errorf("%v: unable to decode postgresPassword due to: %+v", blackduck.Spec.Namespace, err)
+		}
+
 	}
 
 	postgres := containerCreater.GetPostgres()
@@ -85,7 +90,7 @@ func (hc *Creater) getPostgresComponents(blackduck *blackduckapi.Blackduck) (*ap
 		componentList.Services = append(componentList.Services, postgres.GetPostgresService())
 	}
 	componentList.ConfigMaps = append(componentList.ConfigMaps, containerCreater.GetPostgresConfigmap())
-	componentList.Secrets = append(componentList.Secrets, containerCreater.GetPostgresSecret(adminPassword, userPassword))
+	componentList.Secrets = append(componentList.Secrets, containerCreater.GetPostgresSecret(adminPassword, userPassword, postgresPassword))
 
 	return componentList, nil
 }


### PR DESCRIPTION
/assign @msenmurugan @jdartigalongue 

Fixes the bug in which postgres container was using the given `blackduck_user`'s password for the `blackduck` user and `blackduck`'s password for the `postgres` user.

Relates to issue #406, will need to fix the migration process.

This PR is tested and verified on GKE.