### PR TITLE
Added environ checkboxes in webUI

### DIFF
--- a/cmd/operator-ui/templates/blackducks/_form.html
+++ b/cmd/operator-ui/templates/blackducks/_form.html
@@ -9,6 +9,8 @@
     <%= f.SelectTag("Spec.Size", {options: ["Small", "Medium", "Large", "X-Large"], value: blackduck.Spec.Size, label: "Size"}) %>
     <%= f.SelectTag("Spec.ExposeService", {options: {"": "","Load Balancer": "LoadBalancer", "Node Port": "NodePort", "Routes for OpenShift": "OpenShift"}, value: blackduck.Spec.ExposeService, label: "Expose Service"}) %>
     <%= f.InputTag("Spec.Type", {value: blackduck.Spec.Type, label: "Black Duck Type (OpsSight specific)"}) %>
+    <%= f.CheckboxTag("Spec.Environs-USE_BINARY_UPLOADS", {value: false, label:"Use Binary Uploads", onchange:"updateEnvironFromCB('USE_BINARY_UPLOADS', 'int', false)"}) %>
+    <%= f.CheckboxTag("Spec.Environs-ENABLE_SOURCE_UPLOADS", {value: false, label: "Enable Source Uploads", onchange:"updateEnvironFromCB('ENABLE_SOURCE_UPLOADS', 'bool', false)"}) %>
     <%= f.CheckboxTag("Spec.LivenessProbes", {value: blackduck.Spec.LivenessProbes, label: "Liveness Probes"}) %>
     <%= f.CheckboxTag("Spec.PersistentStorage", {value: blackduck.Spec.PersistentStorage, label: "Persistent Storage", onchange: "checkPVC()"}) %>
     <%= f.SelectTag("Spec.DbPrototype", {options: blackduck.View.Clones, value: blackduck.Spec.DbPrototype, label: "Clone DB"}) %>
@@ -59,7 +61,8 @@
       <% } %>
     </ul>
     <label>Environment Variables</label>
-    <ul id="environs" name="environs" contenteditable="true">
+    <ul id="environs" name="environs" contenteditable="true"
+      oninput="update_USE_BINARY_UPLOADS_checkbox() && update_ENABLE_SOURCE_UPLOADS_checkbox()">
       <%= for (environ) in  blackduck.View.Environs { %>
       <li value="<%= environ %>"><%= environ %></li>
       <% } %>
@@ -118,9 +121,95 @@
     document.getElementById("internalDbId").style.display = '';
     document.getElementById("externalDbId").style.display = 'none';
     document.getElementById("customAuthCAId").style.display = 'none';
+    update_USE_BINARY_UPLOADS_checkbox();
+    update_ENABLE_SOURCE_UPLOADS_checkbox();
+    environListRemove("USE_BINARY_UPLOADS");
+    environListRemove("ENABLE_SOURCE_UPLOADS");
     // if (document.getElementById("blackduck-Status.ErrorMessage").value.length > 0) {
     //   document.getElementById("blackduck-Status.ErrorMessage").hidden = false;
     // }
+  }
+
+  function updateCheckbox(elementId, environName, defaultState) {
+    var updatedState = defaultState;
+    var extractedStates = environListExtract(environName);
+    if (!extractedStates.length) {
+      return;
+    }
+    var finalValue = extractedStates[extractedStates.length - 1]["value"];
+    var nonDefaultStr = defaultState == true ? "0" : "1";
+    if (finalValue == nonDefaultStr) {
+      updatedState = !defaultState;
+    }
+    document.getElementById(elementId).checked = updatedState;
+  }
+
+  function update_USE_BINARY_UPLOADS_checkbox() {
+    updateCheckbox(
+      "blackduck-Spec.Environs-USE_BINARY_UPLOADS",
+      "USE_BINARY_UPLOADS",
+      false
+    );
+  }
+
+  function updateEnvironFromCB(envStr, boolType, addIfMissing) {
+    boolT = boolType == 'int' ? '1' : true;
+    boolF = boolType == 'int' ? '0' : false;
+    envCB = document.getElementById("blackduck-Spec.Environs-" + envStr);
+    updateEnviron(envStr, envCB.checked == true ? boolT : boolF, addIfMissing);
+  }
+
+  function update_ENABLE_SOURCE_UPLOADS_checkbox() {
+    updateCheckbox(
+      "blackduck-Spec.Environs-ENABLE_SOURCE_UPLOADS",
+      "ENABLE_SOURCE_UPLOADS",
+      false
+    );
+  }
+
+  function updateEnviron(environName, newStr, insertIfMissing) {
+    var extractedStates = environListExtract(environName);
+    var envElement = document.getElementById("environs");
+    if (extractedStates.length == 0) {
+      if (insertIfMissing) {
+        environListInsert(environName, newStr);
+      } else {
+        return;
+      }
+    }
+    var finalExtractedState = extractedStates[extractedStates.length - 1];
+    var changeIndex = finalExtractedState["index"];
+    envElement.children[changeIndex].innerHTML = environName + ":" + newStr;
+  }
+
+  function environListExtract(environName) {
+    var searchStr = environName + ":"
+    var results = [];
+    for (var i in document.getElementById("environs").children) {
+      var envStr = document.getElementById("environs").children[i].innerHTML;
+      if (typeof envStr == "string" && envStr.startsWith(searchStr)) {
+        results.push({
+          index: i,
+          value: envStr.slice(searchStr.length)
+        });
+      }
+    }
+    return results;
+  }
+
+  function environListRemove(environName) {
+    var toRemove = environListExtract(environName);
+    var envList = document.getElementById("environs");
+    while (toRemove.length) {
+      envList.removeChild(envList.children[toRemove.pop()["index"]]);
+    }
+  }
+
+  function environListInsert(environName, newStr) {
+    envList = document.getElementById("environs");
+    var newEnvLi = document.createElement('li');
+    newEnvLi.appendChild(document.createTextNode(environName + ":" + newStr));
+    envList.appendChild(newEnvLi);
   }
 
   function editableFalse() {
@@ -208,6 +297,10 @@
 
   // add or update environs and update the spec
   function validateAndGetValues() {
+    // Reinsert removed checkbox lines
+    updateEnvironFromCB("USE_BINARY_UPLOADS", 'int', true);
+    updateEnviron("ENABLE_SOURCE_UPLOADS", 'bool', true);
+
     var environsList = document.getElementById("environs");
     var environsItems = environsList.getElementsByTagName('li');
     var environs = document.getElementById("blackduck-Spec.Environs")


### PR DESCRIPTION
Taken from @VSharapov PR #434 , formatted the html on top of it.

/closes #415.
/closes #416.

/assign @msenmurugan 


Added enable-binary-analysis checkbox in webUI
Added enable-source-uploads checkbox in webUI
Implemented Senthil's suggestions
Environs which have a widget are removed from the list
If a user adds them back manually, they are synchronised as before
On form submission, they are sunced and added to the list if missing
Cleaned up JS format https://www.freeformatter.com/javascript-beautifier.html
format html