### PR TITLE
Do not make both the external and internal postgres configuration required

### DIFF
--- a/cmd/operator-ui/templates/blackducks/_form.html
+++ b/cmd/operator-ui/templates/blackducks/_form.html
@@ -28,18 +28,18 @@
     </div>
     <%= f.CheckboxTag("externalDbCheckbox", {label: "External Database", onchange: "toggleDbCheckbox(this)"}) %>
     <div id="externalDbId">
-      <%= f.InputTag("Spec.ExternalPostgres.PostgresHost", {value: blackduck.Spec.ExternalPostgres.PostgresHost, label: "PostgreSQL Host", required: true}) %>
-      <%= f.InputTag("Spec.ExternalPostgres.PostgresPort", {value: blackduck.Spec.ExternalPostgres.PostgresPort, label: "PostgreSQL Port", required: true}) %>
-      <%= f.InputTag("Spec.ExternalPostgres.PostgresAdmin", {value: blackduck.Spec.ExternalPostgres.PostgresAdmin, label: "PostgreSQL Admin User", placeholder: "blackduck", required: true}) %>
-      <%= f.InputTag("Spec.ExternalPostgres.PostgresAdminPassword", {value: blackduck.Spec.ExternalPostgres.PostgresAdminPassword, label: "PostgreSQL Admin Password", required: true}) %>
-      <%= f.InputTag("Spec.ExternalPostgres.PostgresUser", {value: blackduck.Spec.ExternalPostgres.PostgresUser, label: "PostgreSQL User", placeholder: "blackduck_user", required: true}) %>
-      <%= f.InputTag("Spec.ExternalPostgres.PostgresUserPassword", {value: blackduck.Spec.ExternalPostgres.PostgresUserPassword, label: "PostgreSQL User Password", required: true}) %>
-      <%= f.CheckboxTag("Spec.ExternalPostgres.PostgresSsl", {value: blackduck.Spec.ExternalPostgres.PostgresSsl, label: "Enable SSL", required: true}) %>
+      <%= f.InputTag("Spec.ExternalPostgres.PostgresHost", {value: blackduck.Spec.ExternalPostgres.PostgresHost, label: "PostgreSQL Host"}) %>
+      <%= f.InputTag("Spec.ExternalPostgres.PostgresPort", {value: blackduck.Spec.ExternalPostgres.PostgresPort, label: "PostgreSQL Port"}) %>
+      <%= f.InputTag("Spec.ExternalPostgres.PostgresAdmin", {value: blackduck.Spec.ExternalPostgres.PostgresAdmin, label: "PostgreSQL Admin User", placeholder: "blackduck"}) %>
+      <%= f.InputTag("Spec.ExternalPostgres.PostgresAdminPassword", {value: blackduck.Spec.ExternalPostgres.PostgresAdminPassword, label: "PostgreSQL Admin Password"}) %>
+      <%= f.InputTag("Spec.ExternalPostgres.PostgresUser", {value: blackduck.Spec.ExternalPostgres.PostgresUser, label: "PostgreSQL User", placeholder: "blackduck_user"}) %>
+      <%= f.InputTag("Spec.ExternalPostgres.PostgresUserPassword", {value: blackduck.Spec.ExternalPostgres.PostgresUserPassword, label: "PostgreSQL User Password"}) %>
+      <%= f.CheckboxTag("Spec.ExternalPostgres.PostgresSsl", {value: blackduck.Spec.ExternalPostgres.PostgresSsl, label: "Enable SSL"}) %>
     </div>
     <div id="internalDbId">
-      <%= f.InputTag("Spec.UserPassword", {value: blackduck.Spec.UserPassword, label: "PostgreSQL User Password", required: true}) %>
-      <%= f.InputTag("Spec.AdminPassword", {value: blackduck.Spec.AdminPassword, label: "PostgreSQL Admin Password", required: true}) %>
-      <%= f.InputTag("Spec.PostgresPassword", {value: blackduck.Spec.PostgresPassword, label: "PostgreSQL Postgres Password", required: true}) %>
+      <%= f.InputTag("Spec.UserPassword", {value: blackduck.Spec.UserPassword, label: "PostgreSQL User Password"}) %>
+      <%= f.InputTag("Spec.AdminPassword", {value: blackduck.Spec.AdminPassword, label: "PostgreSQL Admin Password"}) %>
+      <%= f.InputTag("Spec.PostgresPassword", {value: blackduck.Spec.PostgresPassword, label: "PostgreSQL Postgres Password"}) %>
     </div>
     <%= f.SelectTag("Spec.CertificateName", {value: blackduck.Spec.CertificateName, options: blackduck.View.CertificateNames, label: "Certificate Name", onchange: "checkNginxCertificate()"}) %>
     <div id="certificateId">


### PR DESCRIPTION
It is impossible to create any Blackduck instance since #389 because it made both the internal and external configuration required. This PR ensures that we only check the external or internal fields depending on the configuration 

/assign @msenmurugan  @rrati  @yashbhutwala 