### PR TITLE
update operator fix

### DIFF
--- a/pkg/synopsysctl/cmd_deploy.go
+++ b/pkg/synopsysctl/cmd_deploy.go
@@ -61,7 +61,7 @@ var mockKubeFormat string
 // deployCmd creates a Synopsys Operator instance in the cluster
 var deployCmd = &cobra.Command{
 	Use:     "deploy",
-	Example: "synopsysctl deploy\nsynopsysctl deploy --enable-blackduck\nsynopsysctl deploy -n <namespace>\nsynopsysctl deploy -n <namespace> --enable-blackduck\nsynopsysctl deploy --expose-ui LOADBALANCER",
+	Example: "synopsysctl deploy --enable-blackduck\nsynopsysctl deploy -n <namespace> --enable-blackduck",
 	Short:   "Deploy Synopsys Operator into your cluster",
 	Args: func(cmd *cobra.Command, args []string) error {
 		// Check number of arguments


### PR DESCRIPTION
* support upgrades for 2019.4.x and older
* update operator fix
* while disabling the crd during update time, then check whether any other instance is already running, if running, provide the error message, if not, delete the crd.