### PR TITLE
Attempt to lock dep versions

### DIFF
--- a/cmd/operator-ui/go.mod
+++ b/cmd/operator-ui/go.mod
@@ -3,11 +3,27 @@ module github.com/blackducksoftware/synopsys-operator/cmd/operator-ui
 go 1.12
 
 replace (
+	github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.2.0
 	github.com/blackducksoftware/synopsys-operator => github.com/blackducksoftware/synopsys-operator v0.0.0-20190619142920-09b2da2fed54
+	github.com/docker/spdystream => github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c
+	github.com/gobuffalo/buffalo => github.com/gobuffalo/buffalo v0.14.6
+	github.com/gobuffalo/envy => github.com/gobuffalo/envy v1.7.0
+	github.com/gobuffalo/mw-csrf => github.com/gobuffalo/mw-csrf v0.0.0-20190129204204-25460a055517
+	github.com/gobuffalo/mw-forcessl => github.com/gobuffalo/mw-forcessl v0.0.0-20190224202501-6d1ef7ffb276
+	github.com/gobuffalo/mw-i18n => github.com/gobuffalo/mw-i18n v0.0.0-20190224203426-337de00e4c33
+	github.com/gobuffalo/mw-paramlogger => github.com/gobuffalo/mw-paramlogger v0.0.0-20190224201358-0d45762ab655
+	github.com/gobuffalo/packr/v2 => github.com/gobuffalo/packr/v2 v2.4.0
 	github.com/golang/lint => github.com/golang/lint v0.0.0-20190409202823-5614ed5bae6fb75893070bdc0996a68765fdd275
+	github.com/google/gofuzz => github.com/google/gofuzz v1.0.0
+	github.com/pkg/errors => github.com/pkg/errors v0.8.1
+	github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.4.2
+	github.com/unrolled/secure => github.com/unrolled/secure v1.0.0
+	gopkg.in/inf.v0 => gopkg.in/inf.v0 v0.9.1
 	k8s.io/api => k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190315093550-53c4693659ed
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1
+	k8s.io/client-go => k8s.io/client-go v11.0.0+incompatible
+	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190603182131-db7b694dc208
 	sourcegraph.com/sourcegraph/go-diff => sourcegraph.com/sourcegraph/go-diff v0.5.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,42 @@ require (
 )
 
 replace (
+	cloud.google.com/go => cloud.google.com/go v0.40.0
+	github.com/blackducksoftware/horizon => github.com/blackducksoftware/horizon v0.0.0-20190603173136-e141457f7a80
+	github.com/blackducksoftware/synopsys-operator/cmd/operator-ui => github.com/blackducksoftware/synopsys-operator/cmd/operator-ui v0.0.0-20190614224807-8d080a4e981c
+	github.com/evanphx/json-patch => github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.4.0
+	github.com/go-logfmt/logfmt => github.com/go-logfmt/logfmt v0.4.0
+	github.com/google/go-cmp => github.com/google/go-cmp v0.3.0
+	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.3.0
+	github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.2.0
+	github.com/imdario/mergo => github.com/imdario/mergo v0.3.7
+	github.com/juju/errors => github.com/juju/errors v0.0.0-20190207033735-e65537c515d7
+	github.com/juju/testing => github.com/juju/testing v0.0.0-20190613124551-e81189438503
+	github.com/lib/pq => github.com/lib/pq v1.1.1
+	github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
+	github.com/onsi/ginkgo => github.com/onsi/ginkgo v1.8.0
+	github.com/onsi/gomega => github.com/onsi/gomega v1.5.0
+	github.com/openshift/api => github.com/openshift/api v3.9.0+incompatible
+	github.com/openshift/client-go => github.com/openshift/client-go v3.9.0+incompatible
+	github.com/pkg/errors => github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.4
+	github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.4.2
+	github.com/spf13/cobra => github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag => github.com/spf13/pflag v1.0.3
+	github.com/spf13/viper => github.com/spf13/viper v1.4.0
+	github.com/stretchr/testify => github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto => golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
+	golang.org/x/net => golang.org/x/net v0.0.0-20190611141213-3f473d35a33a
+	golang.org/x/sys => golang.org/x/sys v0.0.0-20190613124609-5ed2794edfdc
+	google.golang.org/appengine => google.golang.org/appengine v1.6.1
+	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20190611190212-a7e196e89fd3
+	google.golang.org/grpc => google.golang.org/grpc v1.21.1
 	k8s.io/api => k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190315093550-53c4693659ed
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190313205120-d7deff9243b1
+	k8s.io/client-go => k8s.io/client-go v11.0.0+incompatible
+	k8s.io/klog => k8s.io/klog v0.3.3
+	k8s.io/utils => k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a
+	sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.1.0
 )


### PR DESCRIPTION
Trying to lock dep versions so go build doesn't update primary dep versions automatically.