### PR TITLE
bug fixes

### DIFF
--- a/cmd/operator/run.go
+++ b/cmd/operator/run.go
@@ -84,6 +84,10 @@ func runProtoform(configPath string, version string) {
 			// start the CRD controller
 			startController(deployer, strings.TrimSpace(crd), stopCh)
 		}
+		if err := deployer.Deploy(); err != nil {
+			log.Errorf("unable to deploy the CRD controllers due to  %+v", err)
+			os.Exit(1)
+		}
 	} else {
 		log.Errorf("unable to start any CRD controllers. Please set the CrdNames environment variable to start any CRD controllers...")
 		os.Exit(1)
@@ -116,11 +120,7 @@ func startController(deployer *protoform.Deployer, name string, stopCh chan stru
 	default:
 		log.Warnf("unable to start the %s custom resource definition controller due to invalid custom resource definition name", name)
 	}
-	if err := deployer.Deploy(); err != nil {
-		log.Errorf("unable to deploy the CRD controllers due to  %+v", err)
-		os.Exit(1)
-	}
-	log.Infof("started %s crd controller", name)
+	log.Infof("added %s crd controller", name)
 }
 
 func kill(stopCh chan struct{}) {

--- a/pkg/alert/crdhandler.go
+++ b/pkg/alert/crdhandler.go
@@ -126,7 +126,7 @@ func (h *Handler) ObjectUpdated(objOld, objNew interface{}) {
 	if _, ok = alert.Annotations["synopsys.com/created.by"]; !ok {
 		alert.Annotations = util.InitAnnotations(alert.Annotations)
 		alert.Annotations["synopsys.com/created.by"] = h.config.Version
-		alert, err = util.UpdateAlert(h.alertClient, alert.Spec.Namespace, alert)
+		alert, err = util.UpdateAlert(h.alertClient, h.config.Namespace, alert)
 		if err != nil {
 			log.Errorf("couldn't update the annotation for %s Alert instance in %s namespace due to %+v", alert.Name, alert.Spec.Namespace, err)
 			return

--- a/pkg/apps/alert/latest/alert_creater.go
+++ b/pkg/apps/alert/latest/alert_creater.go
@@ -71,7 +71,7 @@ func (ac *Creater) Ensure(alert *alertapi.Alert) error {
 		return err
 	}
 	if strings.EqualFold(alert.Spec.DesiredState, "STOP") {
-		commonConfig := crdupdater.NewCRUDComponents(ac.kubeConfig, ac.kubeClient, ac.config.DryRun, false, alert.Spec.Namespace,
+		commonConfig := crdupdater.NewCRUDComponents(ac.kubeConfig, ac.kubeClient, ac.config.DryRun, false, alert.Spec.Namespace, alert.Spec.Version,
 			&api.ComponentList{PersistentVolumeClaims: cpList.PersistentVolumeClaims}, fmt.Sprintf("app=%s,name=%s", util.AlertName, alert.Name), false)
 		_, errors := commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -79,7 +79,8 @@ func (ac *Creater) Ensure(alert *alertapi.Alert) error {
 		}
 	} else {
 		// Update components in cluster
-		commonConfig := crdupdater.NewCRUDComponents(ac.kubeConfig, ac.kubeClient, ac.config.DryRun, false, alert.Spec.Namespace, cpList, fmt.Sprintf("app=%s,name=%s", util.AlertName, alert.Name), false)
+		commonConfig := crdupdater.NewCRUDComponents(ac.kubeConfig, ac.kubeClient, ac.config.DryRun, false, alert.Spec.Namespace, alert.Spec.Version,
+			cpList, fmt.Sprintf("app=%s,name=%s", util.AlertName, alert.Name), false)
 		_, errors := commonConfig.CRUDComponents()
 		if len(errors) > 0 {
 			return fmt.Errorf("unable to update Alert components due to %+v", errors)

--- a/pkg/apps/blackduck/latest/creater.go
+++ b/pkg/apps/blackduck/latest/creater.go
@@ -68,7 +68,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 
 	if strings.EqualFold(blackduck.Spec.DesiredState, "STOP") {
 		// Save/Update the PVCs for the Black Duck
-		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace,
+		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			&api.ComponentList{PersistentVolumeClaims: pvcs}, fmt.Sprintf("app=%s,name=%s", util.BlackDuckName, blackduck.Name), false)
 		_, errors := commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -76,7 +76,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 	} else if strings.EqualFold(blackduck.Spec.DesiredState, "DbMigrate") {
 		// Save/Update the PVCs for the Black Duck
-		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace,
+		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			&api.ComponentList{PersistentVolumeClaims: pvcs}, fmt.Sprintf("app=%s,name=%s", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors := commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -88,7 +88,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		if err != nil {
 			return err
 		}
-		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace,
+		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			cpPostgresList, fmt.Sprintf("app=%s,name=%s,component=postgres", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors = commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -96,7 +96,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 	} else {
 		// Save/Update the PVCs for the Black Duck
-		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace,
+		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			&api.ComponentList{PersistentVolumeClaims: pvcs}, fmt.Sprintf("app=%s,name=%s,component=pvc", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors := commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -110,7 +110,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// install postgres
-		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace,
+		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			cpPostgresList, fmt.Sprintf("app=%s,name=%s,component=postgres", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors = commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -134,7 +134,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// install cfssl
-		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace,
+		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			cpList, fmt.Sprintf("app=%s,name=%s,component in (configmap,serviceAccount,cfssl)", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors = commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -147,7 +147,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// deploy non postgres and uploadcache component
-		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace,
+		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			cpList, fmt.Sprintf("app=%s,name=%s,component notin (postgres,cfssl,configmap,serviceAccount,uploadcache,route)", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors = commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -156,7 +156,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		// log.Debugf("created/updated non postgres and upload cache component for %s", blackduck.Spec.Namespace)
 
 		// deploy upload cache component
-		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace,
+		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			cpList, fmt.Sprintf("app=%s,name=%s,component in (uploadcache,route)", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors = commonConfig.CRUDComponents()
 		if len(errors) > 0 {

--- a/pkg/apps/blackduck/v1/creater.go
+++ b/pkg/apps/blackduck/v1/creater.go
@@ -67,14 +67,14 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 	pvcs := hc.GetPVC(blackduck)
 
 	if strings.EqualFold(blackduck.Spec.DesiredState, "STOP") {
-		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace,
+		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			&api.ComponentList{PersistentVolumeClaims: pvcs}, fmt.Sprintf("app=%s,name=%s", util.BlackDuckName, blackduck.Name), false)
 		_, errors := commonConfig.CRUDComponents()
 		if len(errors) > 0 {
 			return fmt.Errorf("stop blackduck: %+v", errors)
 		}
 	} else {
-		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace,
+		commonConfig := crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, false, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			&api.ComponentList{PersistentVolumeClaims: pvcs}, fmt.Sprintf("app=%s,name=%s,component=pvc", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors := commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -88,7 +88,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// install postgres
-		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace,
+		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			cpPostgresList, fmt.Sprintf("app=%s,name=%s,component=postgres", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors = commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -112,7 +112,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 		}
 
 		// install cfssl
-		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace,
+		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			cpList, fmt.Sprintf("app=%s,name=%s,component in (configmap,serviceAccount,cfssl)", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors = commonConfig.CRUDComponents()
 		if len(errors) > 0 {
@@ -124,7 +124,7 @@ func (hc *Creater) Ensure(blackduck *blackduckapi.Blackduck) error {
 			return fmt.Errorf("the cfssl pod is not ready: %v", err)
 		}
 		// deploy non postgres and uploadcache component
-		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace,
+		commonConfig = crdupdater.NewCRUDComponents(hc.kubeConfig, hc.kubeClient, hc.config.DryRun, isPatched, blackduck.Spec.Namespace, blackduck.Spec.Version,
 			cpList, fmt.Sprintf("app=%s,name=%s,component notin (postgres,configmap,serviceAccount,cfssl)", util.BlackDuckName, blackduck.Name), false)
 		isPatched, errors = commonConfig.CRUDComponents()
 		if len(errors) > 0 {

--- a/pkg/blackduck/crdhandler.go
+++ b/pkg/blackduck/crdhandler.go
@@ -143,7 +143,7 @@ func (h *Handler) ObjectUpdated(objOld, objNew interface{}) {
 	if _, ok = bd.Annotations["synopsys.com/created.by"]; !ok {
 		bd.Annotations = util.InitAnnotations(bd.Annotations)
 		bd.Annotations["synopsys.com/created.by"] = h.config.Version
-		bd, err = util.UpdateBlackduck(h.blackduckClient, bd.Spec.Namespace, bd)
+		bd, err = util.UpdateBlackduck(h.blackduckClient, h.config.Namespace, bd)
 		if err != nil {
 			log.Errorf("couldn't update the annotation for %s Black Duck instance in %s namespace due to %+v", bd.Name, bd.Spec.Namespace, err)
 			return

--- a/pkg/crdupdater/crudcomponents.go
+++ b/pkg/crdupdater/crudcomponents.go
@@ -38,6 +38,7 @@ type CommonConfig struct {
 	dryRun                    bool
 	isPatched                 bool
 	namespace                 string
+	version                   string
 	components                *api.ComponentList
 	labelSelector             string
 	expectedLabels            map[string]label
@@ -47,14 +48,15 @@ type CommonConfig struct {
 }
 
 // NewCRUDComponents returns the common configuration which will be used to add, patch or remove the components
-func NewCRUDComponents(kubeConfig *rest.Config, kubeClient *kubernetes.Clientset, dryRun bool, isPatched bool,
-	namespace string, components *api.ComponentList, labelSelector string, isClusterLevelPermEnabled bool) *CommonConfig {
+func NewCRUDComponents(kubeConfig *rest.Config, kubeClient *kubernetes.Clientset, dryRun bool, isPatched bool, namespace string,
+	version string, components *api.ComponentList, labelSelector string, isClusterLevelPermEnabled bool) *CommonConfig {
 	return &CommonConfig{
 		kubeConfig:                kubeConfig,
 		kubeClient:                kubeClient,
 		dryRun:                    dryRun,
 		isPatched:                 isPatched,
 		namespace:                 namespace,
+		version:                   version,
 		components:                components,
 		labelSelector:             labelSelector,
 		expectedLabels:            getLabelsMap(labelSelector),

--- a/pkg/crdupdater/namespace.go
+++ b/pkg/crdupdater/namespace.go
@@ -22,10 +22,14 @@ under the License.
 package crdupdater
 
 import (
+	"fmt"
+
 	horizonapi "github.com/blackducksoftware/horizon/pkg/api"
 	"github.com/blackducksoftware/horizon/pkg/components"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	"github.com/juju/errors"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Namespace stores the configuration to add or delete the namespace
@@ -53,18 +57,35 @@ func (n *Namespace) buildNewAndOldObject() error {
 
 // add adds the namespace
 func (n *Namespace) add(isPatched bool) (bool, error) {
-	_, err := n.get(n.config.namespace)
+	ns, err := n.get(n.config.namespace)
 	if err != nil {
 		namespace := components.NewNamespace(
 			horizonapi.NamespaceConfig{
 				Name:      n.config.namespace,
 				Namespace: n.config.namespace,
 			})
-		namespace.AddLabels(map[string]string{"owner": "synopsys-operator"})
+		labels := make(map[string]string, 0)
+		labels["owner"] = util.OperatorName
+		var app, name string
+		if appVal, ok := n.config.expectedLabels["app"]; ok {
+			app = appVal.value[0]
+		}
+		if nameVal, ok := n.config.expectedLabels["name"]; ok {
+			name = nameVal.value[0]
+		}
+		if len(app) > 0 && len(name) > 0 && len(n.config.version) > 0 {
+			labels[fmt.Sprintf("synopsys.com/%s.%s", app, name)] = n.config.version
+		} else if len(n.config.version) > 0 {
+			log.Errorf("unable to add the Synopsys label because app: %s, name: %s, version: %s is missing", app, name, n.config.namespace)
+		}
+		namespace.AddLabels(labels)
 		n.deployer.Deployer.AddComponent(horizonapi.NamespaceComponent, namespace)
-		n.deployer.Deployer.Run()
+		err := n.deployer.Deployer.Run()
+		if err != nil {
+			return false, fmt.Errorf("unable to create namespace due to %+v", err)
+		}
 	}
-	return false, nil
+	return n.patch(ns, false)
 }
 
 // get get the namespace
@@ -89,5 +110,26 @@ func (n *Namespace) remove() error {
 
 // patch patches the namespace
 func (n *Namespace) patch(ns interface{}, isPatched bool) (bool, error) {
+	namespace := ns.(*corev1.Namespace)
+	namespace.Labels = util.InitLabels(namespace.Labels)
+	var app, name string
+	if appVal, ok := n.config.expectedLabels["app"]; ok {
+		app = appVal.value[0]
+	}
+	if nameVal, ok := n.config.expectedLabels["name"]; ok {
+		name = nameVal.value[0]
+	}
+	if val, ok := namespace.Labels[fmt.Sprintf("synopsys.com/%s.%s", app, name)]; !ok || val != n.config.version {
+		if len(app) > 0 && len(name) > 0 && len(n.config.version) > 0 {
+			log.Debugf("patch namespace for synopsys label in namespace '%s'", namespace.Name)
+			namespace.Labels[fmt.Sprintf("synopsys.com/%s.%s", app, name)] = n.config.version
+			_, err := util.UpdateNamespace(n.config.kubeClient, namespace)
+			if err != nil {
+				return false, fmt.Errorf("unable to update namespace %s due to %+v", namespace.GetName(), err)
+			}
+		} else if len(n.config.version) > 0 {
+			log.Errorf("unable to update the Synopsys label because app: %s, name: %s, version: %s is missing", app, name, n.config.namespace)
+		}
+	}
 	return false, nil
 }

--- a/pkg/opssight/configmap.go
+++ b/pkg/opssight/configmap.go
@@ -123,7 +123,7 @@ func (cm *MainOpssightConfigMap) horizonConfigMap(name string, namespace string,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	configMap.AddLabels(map[string]string{"name": name, "app": "opssight"})
+	configMap.AddLabels(map[string]string{"component": name, "app": "opssight"})
 	configMap.AddData(map[string]string{filename: configMapString})
 
 	return configMap, nil

--- a/pkg/opssight/crdinstaller.go
+++ b/pkg/opssight/crdinstaller.go
@@ -84,7 +84,7 @@ func (c *CRDInstaller) Deploy() error {
 		return errors.Trace(err)
 	}
 	crdUpdater := NewUpdater(c.config, c.kubeClient, blackDuckClient, c.opssightclient)
-	crdUpdater.Run(c.stopCh)
+	go crdUpdater.Run(c.stopCh)
 	return nil
 }
 
@@ -112,7 +112,6 @@ func (c *CRDInstaller) CreateQueue() {
 
 // AddInformerEventHandler will add the event handlers for the informers
 func (c *CRDInstaller) AddInformerEventHandler() {
-	log.Debugf("adding informer event handler for opssight")
 	c.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			// convert the resource object into a key (in this case

--- a/pkg/opssight/perceptor.go
+++ b/pkg/opssight/perceptor.go
@@ -40,7 +40,7 @@ func (p *SpecConfig) PerceptorReplicationController() (*components.ReplicationCo
 	replicas := int32(1)
 	rc := components.NewReplicationController(horizonapi.ReplicationControllerConfig{
 		Replicas:  &replicas,
-		Name:      p.opssight.Spec.Perceptor.Name,
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Perceptor.Name),
 		Namespace: p.opssight.Spec.Namespace,
 	})
 	pod, err := p.perceptorPod()
@@ -48,16 +48,16 @@ func (p *SpecConfig) PerceptorReplicationController() (*components.ReplicationCo
 		return nil, errors.Trace(err)
 	}
 	rc.AddPod(pod)
-	rc.AddSelectors(map[string]string{"name": p.opssight.Spec.Perceptor.Name, "app": "opssight"})
-	rc.AddLabels(map[string]string{"name": p.opssight.Spec.Perceptor.Name, "app": "opssight"})
+	rc.AddSelectors(map[string]string{"component": p.opssight.Spec.Perceptor.Name, "app": "opssight", "name": p.opssight.Name})
+	rc.AddLabels(map[string]string{"component": p.opssight.Spec.Perceptor.Name, "app": "opssight", "name": p.opssight.Name})
 	return rc, nil
 }
 
 func (p *SpecConfig) perceptorPod() (*components.Pod, error) {
 	pod := components.NewPod(horizonapi.PodConfig{
-		Name: p.opssight.Spec.Perceptor.Name,
+		Name: util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Perceptor.Name),
 	})
-	pod.AddLabels(map[string]string{"name": p.opssight.Spec.Perceptor.Name, "app": "opssight"})
+	pod.AddLabels(map[string]string{"component": p.opssight.Spec.Perceptor.Name, "app": "opssight", "name": p.opssight.Name})
 	cont, err := p.perceptorContainer()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -77,10 +77,14 @@ func (p *SpecConfig) perceptorPod() (*components.Pod, error) {
 
 func (p *SpecConfig) perceptorContainer() (*components.Container, error) {
 	name := p.opssight.Spec.Perceptor.Name
+	command := name
+	if name == "core" {
+		command = fmt.Sprintf("opssight-%s", name)
+	}
 	container, err := components.NewContainer(horizonapi.ContainerConfig{
 		Name:    name,
 		Image:   p.opssight.Spec.Perceptor.Image,
-		Command: []string{fmt.Sprintf("./%s", name)},
+		Command: []string{fmt.Sprintf("./%s", command)},
 		Args:    []string{fmt.Sprintf("/etc/%s/%s.json", name, p.opssight.Spec.ConfigMapName)},
 		MinCPU:  p.opssight.Spec.DefaultCPU,
 		MinMem:  p.opssight.Spec.DefaultMem,
@@ -101,7 +105,7 @@ func (p *SpecConfig) perceptorContainer() (*components.Container, error) {
 		return nil, errors.Trace(err)
 	}
 
-	container.AddEnv(horizonapi.EnvConfig{Type: horizonapi.EnvFromSecret, FromName: p.opssight.Spec.SecretName})
+	container.AddEnv(horizonapi.EnvConfig{Type: horizonapi.EnvFromSecret, FromName: util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.SecretName)})
 
 	return container, nil
 }
@@ -109,7 +113,7 @@ func (p *SpecConfig) perceptorContainer() (*components.Container, error) {
 // PerceptorService creates a service for perceptor
 func (p *SpecConfig) PerceptorService() (*components.Service, error) {
 	service := components.NewService(horizonapi.ServiceConfig{
-		Name:      p.opssight.Spec.Perceptor.Name,
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Perceptor.Name),
 		Namespace: p.opssight.Spec.Namespace,
 		Type:      horizonapi.ServiceTypeServiceIP,
 	})
@@ -124,8 +128,8 @@ func (p *SpecConfig) PerceptorService() (*components.Service, error) {
 		return nil, errors.Trace(err)
 	}
 
-	service.AddLabels(map[string]string{"name": p.opssight.Spec.Perceptor.Name, "app": "opssight"})
-	service.AddSelectors(map[string]string{"name": p.opssight.Spec.Perceptor.Name, "app": "opssight"})
+	service.AddLabels(map[string]string{"component": p.opssight.Spec.Perceptor.Name, "app": "opssight", "name": p.opssight.Name})
+	service.AddSelectors(map[string]string{"component": p.opssight.Spec.Perceptor.Name, "app": "opssight", "name": p.opssight.Name})
 
 	return service, nil
 }
@@ -134,7 +138,7 @@ func (p *SpecConfig) PerceptorService() (*components.Service, error) {
 func (p *SpecConfig) PerceptorNodePortService() (*components.Service, error) {
 	name := fmt.Sprintf("%s-exposed", p.opssight.Spec.Perceptor.Name)
 	service := components.NewService(horizonapi.ServiceConfig{
-		Name:      name,
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, name),
 		Namespace: p.opssight.Spec.Namespace,
 		Type:      horizonapi.ServiceTypeNodePort,
 	})
@@ -149,8 +153,8 @@ func (p *SpecConfig) PerceptorNodePortService() (*components.Service, error) {
 		return nil, errors.Trace(err)
 	}
 
-	service.AddLabels(map[string]string{"name": name, "app": "opssight"})
-	service.AddSelectors(map[string]string{"name": p.opssight.Spec.Perceptor.Name, "app": "opssight"})
+	service.AddLabels(map[string]string{"component": name, "app": "opssight", "name": p.opssight.Name})
+	service.AddSelectors(map[string]string{"component": name, "app": "opssight", "name": p.opssight.Name})
 
 	return service, nil
 }
@@ -159,7 +163,7 @@ func (p *SpecConfig) PerceptorNodePortService() (*components.Service, error) {
 func (p *SpecConfig) PerceptorLoadBalancerService() (*components.Service, error) {
 	name := fmt.Sprintf("%s-exposed", p.opssight.Spec.Perceptor.Name)
 	service := components.NewService(horizonapi.ServiceConfig{
-		Name:      name,
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, name),
 		Namespace: p.opssight.Spec.Namespace,
 		Type:      horizonapi.ServiceTypeLoadBalancer,
 	})
@@ -174,8 +178,8 @@ func (p *SpecConfig) PerceptorLoadBalancerService() (*components.Service, error)
 		return nil, errors.Trace(err)
 	}
 
-	service.AddLabels(map[string]string{"name": name, "app": "opssight"})
-	service.AddSelectors(map[string]string{"name": p.opssight.Spec.Perceptor.Name, "app": "opssight"})
+	service.AddLabels(map[string]string{"component": name, "app": "opssight", "name": p.opssight.Name})
+	service.AddSelectors(map[string]string{"component": name, "app": "opssight", "name": p.opssight.Name})
 
 	return service, nil
 }
@@ -183,7 +187,7 @@ func (p *SpecConfig) PerceptorLoadBalancerService() (*components.Service, error)
 // PerceptorSecret create a secret for perceptor
 func (p *SpecConfig) PerceptorSecret() (*components.Secret, error) {
 	secretConfig := horizonapi.SecretConfig{
-		Name:      p.opssight.Spec.SecretName,
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.SecretName),
 		Namespace: p.opssight.Spec.Namespace,
 		Type:      horizonapi.SecretTypeOpaque,
 	}
@@ -204,7 +208,7 @@ func (p *SpecConfig) PerceptorSecret() (*components.Secret, error) {
 	}
 	secret.AddData(map[string][]byte{"securedRegistries.json": bytes})
 
-	secret.AddLabels(map[string]string{"name": p.opssight.Spec.SecretName, "app": "opssight"})
+	secret.AddLabels(map[string]string{"component": p.opssight.Spec.SecretName, "app": "opssight", "name": p.opssight.Name})
 	return secret, nil
 }
 
@@ -213,12 +217,12 @@ func (p *SpecConfig) GetPerceptorOpenShiftRoute() *api.Route {
 	namespace := p.opssight.Spec.Namespace
 	if strings.ToUpper(p.opssight.Spec.Perceptor.Expose) == util.OPENSHIFT {
 		return &api.Route{
-			Name:               fmt.Sprintf("%s-%s", p.opssight.Spec.Perceptor.Name, namespace),
+			Name:               util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Perceptor.Name),
 			Namespace:          namespace,
 			Kind:               "Service",
-			ServiceName:        p.opssight.Spec.Perceptor.Name,
+			ServiceName:        util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Perceptor.Name),
 			PortName:           fmt.Sprintf("port-%s", p.opssight.Spec.Perceptor.Name),
-			Labels:             map[string]string{"app": "opssight"},
+			Labels:             map[string]string{"app": "opssight", "name": p.opssight.Name, "component": fmt.Sprintf("%s-ui", p.opssight.Spec.Perceptor.Name)},
 			TLSTerminationType: routev1.TLSTerminationEdge,
 		}
 	}

--- a/pkg/opssight/prometheus.go
+++ b/pkg/opssight/prometheus.go
@@ -39,11 +39,11 @@ func (p *SpecConfig) PerceptorMetricsDeployment() (*components.Deployment, error
 	replicas := int32(1)
 	deployment := components.NewDeployment(horizonapi.DeploymentConfig{
 		Replicas:  &replicas,
-		Name:      "prometheus",
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, "prometheus"),
 		Namespace: p.opssight.Spec.Namespace,
 	})
-	deployment.AddLabels(map[string]string{"name": "prometheus", "app": "opssight"})
-	deployment.AddMatchLabelsSelectors(map[string]string{"app": "opssight"})
+	deployment.AddLabels(map[string]string{"component": "prometheus", "app": "opssight", "name": p.opssight.Name})
+	deployment.AddMatchLabelsSelectors(map[string]string{"component": "prometheus", "app": "opssight", "name": p.opssight.Name})
 
 	pod, err := p.perceptorMetricsPod()
 	if err != nil {
@@ -56,9 +56,9 @@ func (p *SpecConfig) PerceptorMetricsDeployment() (*components.Deployment, error
 
 func (p *SpecConfig) perceptorMetricsPod() (*components.Pod, error) {
 	pod := components.NewPod(horizonapi.PodConfig{
-		Name: "prometheus",
+		Name: util.GetResourceName(p.opssight.Name, util.OpsSightName, "prometheus"),
 	})
-	pod.AddLabels(map[string]string{"name": "prometheus", "app": "opssight"})
+	pod.AddLabels(map[string]string{"component": "prometheus", "app": "opssight", "name": p.opssight.Name})
 	container, err := p.perceptorMetricsContainer()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -114,7 +114,7 @@ func (p *SpecConfig) perceptorMetricsVolumes() ([]*components.Volume, error) {
 	vols := []*components.Volume{}
 	vols = append(vols, components.NewConfigMapVolume(horizonapi.ConfigMapOrSecretVolumeConfig{
 		VolumeName:      "prometheus",
-		MapOrSecretName: "prometheus",
+		MapOrSecretName: util.GetResourceName(p.opssight.Name, util.OpsSightName, "prometheus"),
 		DefaultMode:     util.IntToInt32(420),
 	}))
 
@@ -133,7 +133,7 @@ func (p *SpecConfig) perceptorMetricsVolumes() ([]*components.Volume, error) {
 // PerceptorMetricsService creates a service for perceptor metrics
 func (p *SpecConfig) PerceptorMetricsService() (*components.Service, error) {
 	service := components.NewService(horizonapi.ServiceConfig{
-		Name:      "prometheus",
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, "prometheus"),
 		Namespace: p.opssight.Spec.Namespace,
 		Type:      horizonapi.ServiceTypeServiceIP,
 	})
@@ -146,8 +146,8 @@ func (p *SpecConfig) PerceptorMetricsService() (*components.Service, error) {
 	})
 
 	service.AddAnnotations(map[string]string{"prometheus.io/scrape": "true"})
-	service.AddLabels(map[string]string{"name": "prometheus", "app": "opssight"})
-	service.AddSelectors(map[string]string{"name": "prometheus", "app": "opssight"})
+	service.AddLabels(map[string]string{"component": "prometheus", "app": "opssight", "name": p.opssight.Name})
+	service.AddSelectors(map[string]string{"component": "prometheus", "app": "opssight", "name": p.opssight.Name})
 
 	return service, err
 }
@@ -155,7 +155,7 @@ func (p *SpecConfig) PerceptorMetricsService() (*components.Service, error) {
 // PerceptorMetricsNodePortService creates a nodeport service for perceptor metrics
 func (p *SpecConfig) PerceptorMetricsNodePortService() (*components.Service, error) {
 	service := components.NewService(horizonapi.ServiceConfig{
-		Name:      "prometheus-exposed",
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, "prometheus-exposed"),
 		Namespace: p.opssight.Spec.Namespace,
 		Type:      horizonapi.ServiceTypeNodePort,
 	})
@@ -168,8 +168,8 @@ func (p *SpecConfig) PerceptorMetricsNodePortService() (*components.Service, err
 	})
 
 	service.AddAnnotations(map[string]string{"prometheus.io/scrape": "true"})
-	service.AddLabels(map[string]string{"name": "prometheus", "app": "opssight"})
-	service.AddSelectors(map[string]string{"name": "prometheus", "app": "opssight"})
+	service.AddLabels(map[string]string{"component": "prometheus-exposed", "app": "opssight", "name": p.opssight.Name})
+	service.AddSelectors(map[string]string{"component": "prometheus-exposed", "app": "opssight", "name": p.opssight.Name})
 
 	return service, err
 }
@@ -177,7 +177,7 @@ func (p *SpecConfig) PerceptorMetricsNodePortService() (*components.Service, err
 // PerceptorMetricsLoadBalancerService creates a loadbalancer service for perceptor metrics
 func (p *SpecConfig) PerceptorMetricsLoadBalancerService() (*components.Service, error) {
 	service := components.NewService(horizonapi.ServiceConfig{
-		Name:      "prometheus-exposed",
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, "prometheus-exposed"),
 		Namespace: p.opssight.Spec.Namespace,
 		Type:      horizonapi.ServiceTypeLoadBalancer,
 	})
@@ -190,8 +190,8 @@ func (p *SpecConfig) PerceptorMetricsLoadBalancerService() (*components.Service,
 	})
 
 	service.AddAnnotations(map[string]string{"prometheus.io/scrape": "true"})
-	service.AddLabels(map[string]string{"name": "prometheus", "app": "opssight"})
-	service.AddSelectors(map[string]string{"name": "prometheus", "app": "opssight"})
+	service.AddLabels(map[string]string{"component": "prometheus", "app": "opssight", "name": p.opssight.Name})
+	service.AddSelectors(map[string]string{"component": "prometheus", "app": "opssight", "name": p.opssight.Name})
 
 	return service, err
 }
@@ -199,7 +199,7 @@ func (p *SpecConfig) PerceptorMetricsLoadBalancerService() (*components.Service,
 // PerceptorMetricsConfigMap creates a config map for perceptor metrics
 func (p *SpecConfig) PerceptorMetricsConfigMap() (*components.ConfigMap, error) {
 	configMap := components.NewConfigMap(horizonapi.ConfigMapConfig{
-		Name:      "prometheus",
+		Name:      util.GetResourceName(p.opssight.Name, util.OpsSightName, "prometheus"),
 		Namespace: p.opssight.Spec.Namespace,
 	})
 
@@ -229,18 +229,18 @@ func (p *SpecConfig) PerceptorMetricsConfigMap() (*components.ConfigMap, error) 
 		}
 	*/
 	targets := []string{
-		fmt.Sprintf("%s:%d", p.opssight.Spec.Perceptor.Name, p.opssight.Spec.Perceptor.Port),
-		fmt.Sprintf("%s:%d", p.opssight.Spec.ScannerPod.Scanner.Name, p.opssight.Spec.ScannerPod.Scanner.Port),
-		fmt.Sprintf("%s:%d", p.opssight.Spec.ScannerPod.ImageFacade.Name, p.opssight.Spec.ScannerPod.ImageFacade.Port),
+		fmt.Sprintf("%s:%d", util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Perceptor.Name), p.opssight.Spec.Perceptor.Port),
+		fmt.Sprintf("%s:%d", util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.ScannerPod.Scanner.Name), p.opssight.Spec.ScannerPod.Scanner.Port),
+		fmt.Sprintf("%s:%d", util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.ScannerPod.ImageFacade.Name), p.opssight.Spec.ScannerPod.ImageFacade.Port),
 	}
 	if p.opssight.Spec.Perceiver.EnableImagePerceiver {
-		targets = append(targets, fmt.Sprintf("%s:%d", p.opssight.Spec.Perceiver.ImagePerceiver.Name, p.opssight.Spec.Perceiver.Port))
+		targets = append(targets, fmt.Sprintf("%s:%d", util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Perceiver.ImagePerceiver.Name), p.opssight.Spec.Perceiver.Port))
 	}
 	if p.opssight.Spec.Perceiver.EnablePodPerceiver {
-		targets = append(targets, fmt.Sprintf("%s:%d", p.opssight.Spec.Perceiver.PodPerceiver.Name, p.opssight.Spec.Perceiver.Port))
+		targets = append(targets, fmt.Sprintf("%s:%d", util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Perceiver.PodPerceiver.Name), p.opssight.Spec.Perceiver.Port))
 	}
 	if p.opssight.Spec.EnableSkyfire {
-		targets = append(targets, fmt.Sprintf("%s:%d", p.opssight.Spec.Skyfire.Name, p.opssight.Spec.Skyfire.PrometheusPort))
+		targets = append(targets, fmt.Sprintf("%s:%d", util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Skyfire.Name), p.opssight.Spec.Skyfire.PrometheusPort))
 	}
 	data := map[string]interface{}{
 		"global": map[string]interface{}{
@@ -262,7 +262,7 @@ func (p *SpecConfig) PerceptorMetricsConfigMap() (*components.ConfigMap, error) 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	configMap.AddLabels(map[string]string{"app": "opssight"})
+	configMap.AddLabels(map[string]string{"app": "opssight", "name": p.opssight.Name, "component": "prometheus"})
 	configMap.AddData(map[string]string{"prometheus.yml": string(bytes)})
 
 	return configMap, nil
@@ -273,12 +273,12 @@ func (p *SpecConfig) GetPrometheusOpenShiftRoute() *api.Route {
 	namespace := p.opssight.Spec.Namespace
 	if strings.ToUpper(p.opssight.Spec.Perceptor.Expose) == util.OPENSHIFT {
 		return &api.Route{
-			Name:               fmt.Sprintf("%s-%s", p.opssight.Spec.Prometheus.Name, namespace),
+			Name:               util.GetResourceName(p.opssight.Name, util.OpsSightName, fmt.Sprintf("%s-metrics", p.opssight.Spec.Prometheus.Name)),
 			Namespace:          namespace,
 			Kind:               "Service",
-			ServiceName:        p.opssight.Spec.Prometheus.Name,
+			ServiceName:        util.GetResourceName(p.opssight.Name, util.OpsSightName, p.opssight.Spec.Prometheus.Name),
 			PortName:           fmt.Sprintf("port-%s", p.opssight.Spec.Prometheus.Name),
-			Labels:             map[string]string{"app": "opssight"},
+			Labels:             map[string]string{"app": "opssight", "name": p.opssight.Name, "component": "prometheus-metrics"},
 			TLSTerminationType: routev1.TLSTerminationEdge,
 		}
 	}

--- a/pkg/soperator/soperator_creater.go
+++ b/pkg/soperator/soperator_creater.go
@@ -187,7 +187,7 @@ func (sc *Creater) UpdateSOperatorComponents(specConfig *SpecConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to get Synopsys Operator components: %s", err)
 	}
-	sOperatorCommonConfig := crdupdater.NewCRUDComponents(sc.KubeConfig, sc.KubeClient, false, false, specConfig.Namespace, sOperatorComponents, "app=synopsys-operator,component=operator", true)
+	sOperatorCommonConfig := crdupdater.NewCRUDComponents(sc.KubeConfig, sc.KubeClient, false, false, specConfig.Namespace, "", sOperatorComponents, "app=synopsys-operator,component=operator", true)
 	_, errs := sOperatorCommonConfig.CRUDComponents()
 	if errs != nil {
 		return fmt.Errorf("failed to update Synopsys Operator components: %+v", errs)
@@ -202,7 +202,7 @@ func (sc *Creater) UpdatePrometheus(specConfig *PrometheusSpecConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to get Prometheus components: %s", err)
 	}
-	prometheusCommonConfig := crdupdater.NewCRUDComponents(sc.KubeConfig, sc.KubeClient, false, false, specConfig.Namespace, prometheusComponents, "app=synopsys-operator,component=prometheus", true)
+	prometheusCommonConfig := crdupdater.NewCRUDComponents(sc.KubeConfig, sc.KubeClient, false, false, specConfig.Namespace, "", prometheusComponents, "app=synopsys-operator,component=prometheus", true)
 	_, errs := prometheusCommonConfig.CRUDComponents()
 	if errs != nil {
 		return fmt.Errorf("failed to update Prometheus components: %+v", errs)

--- a/pkg/synopsysctl/cmd_db_migrate.go
+++ b/pkg/synopsysctl/cmd_db_migrate.go
@@ -54,7 +54,7 @@ var dbMigrateBlackDuckCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, "", namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, "", namespace, args[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/synopsysctl/cmd_delete.go
+++ b/pkg/synopsysctl/cmd_delete.go
@@ -55,7 +55,7 @@ var deleteAlertCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, alertName := range args {
-			alertName, alertNamespace, _, err := getInstanceInfo(false, alertName, util.AlertCRDName, util.AlertName, namespace)
+			alertName, alertNamespace, _, err := getInstanceInfo(false, util.AlertCRDName, util.AlertName, namespace, alertName)
 			if err != nil {
 				return err
 			}
@@ -87,7 +87,7 @@ var deleteBlackDuckCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, blackDuckName := range args {
-			blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, blackDuckName, util.BlackDuckCRDName, util.BlackDuckName, namespace)
+			blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, blackDuckName)
 			if err != nil {
 				return err
 			}
@@ -119,7 +119,7 @@ var deleteOpsSightCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		for _, opsSightName := range args {
-			opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, opsSightName, util.OpsSightCRDName, util.OpsSightName, namespace)
+			opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, opsSightName)
 			if err != nil {
 				return err
 			}

--- a/pkg/synopsysctl/cmd_edit.go
+++ b/pkg/synopsysctl/cmd_edit.go
@@ -53,7 +53,7 @@ var editAlertCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		alertName, alertNamespace, _, err := getInstanceInfo(false, args[0], util.AlertCRDName, util.AlertName, namespace)
+		alertName, alertNamespace, _, err := getInstanceInfo(false, util.AlertCRDName, util.AlertName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ var editBlackDuckCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -113,7 +113,7 @@ var editOpsSightCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/synopsysctl/cmd_get.go
+++ b/pkg/synopsysctl/cmd_get.go
@@ -30,8 +30,6 @@ import (
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Get Command flag for -output functionality
@@ -138,19 +136,14 @@ var getBlackDuckRootKeyCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		blackDuckName, blackDuckNamespace, crdScope, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, crdScope, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
 
-		var operatorNamespace string
-		if crdScope == apiextensions.ClusterScoped {
-			operatorNamespace, err = getOperatorNamespace(metav1.NamespaceAll)
-			if err != nil {
-				return fmt.Errorf("unable to find the Synopsys Operator instance due to %+v", err)
-			}
-		} else {
-			operatorNamespace = namespace
+		operatorNamespace, err := util.GetOperatorNamespaceByCRDScope(kubeClient, util.BlackDuckCRDName, crdScope, blackDuckNamespace)
+		if err != nil {
+			return fmt.Errorf("unable to find the Synopsys Operator instance due to %+v", err)
 		}
 
 		filePath := args[1]

--- a/pkg/synopsysctl/cmd_start.go
+++ b/pkg/synopsysctl/cmd_start.go
@@ -53,7 +53,7 @@ var startAlertCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		alertName, alertNamespace, _, err := getInstanceInfo(false, args[0], util.AlertCRDName, util.AlertName, namespace)
+		alertName, alertNamespace, _, err := getInstanceInfo(false, util.AlertCRDName, util.AlertName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -94,7 +94,7 @@ var startBlackDuckCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -135,7 +135,7 @@ var startOpsSightCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/synopsysctl/cmd_stop.go
+++ b/pkg/synopsysctl/cmd_stop.go
@@ -53,7 +53,7 @@ var stopAlertCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		alertName, alertNamespace, _, err := getInstanceInfo(false, args[0], util.AlertCRDName, util.AlertName, namespace)
+		alertName, alertNamespace, _, err := getInstanceInfo(false, util.AlertCRDName, util.AlertName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ var stopBlackDuckCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ var stopOpsSightCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -23,7 +23,6 @@ package synopsysctl
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -36,7 +35,6 @@ import (
 	opssightapi "github.com/blackducksoftware/synopsys-operator/pkg/api/opssight/v1"
 	blackduck "github.com/blackducksoftware/synopsys-operator/pkg/blackduck"
 	opssight "github.com/blackducksoftware/synopsys-operator/pkg/opssight"
-	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
 	soperator "github.com/blackducksoftware/synopsys-operator/pkg/soperator"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	"github.com/imdario/mergo"
@@ -68,57 +66,19 @@ var updateCmd = &cobra.Command{
 Update Operator Commands
 */
 
-// getOperatorToUpdate creates a SpecConfig that represents the Synopsys Operator running in the cluster
-func getOperatorToUpdate(namespace string, cmd *cobra.Command) (*soperator.SpecConfig, map[string]string, []string, error) {
-	crds := []string{}
-	crdMap := make(map[string]string)
-
-	// check whether the Synopsys Operator config map exist
-	cm, err := util.GetConfigMap(kubeClient, namespace, "synopsys-operator")
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to find the 'synopsy-operator' config map in namespace '%s' due to %+v", namespace, err)
-	}
-	data := cm.Data["config.json"]
-	var testMap map[string]interface{}
-	err = json.Unmarshal([]byte(data), &testMap)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to unmarshal config map data due to %+v", err)
-	}
-	if _, ok := testMap["IsClusterScoped"]; ok {
-		configData := &protoform.Config{}
-		err = json.Unmarshal([]byte(data), &configData)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("unable to unmarshal config map data due to %+v", err)
-		}
-		isClusterScoped = configData.IsClusterScoped
-		crds = strings.Split(configData.CrdNames, ",")
-		for _, crd := range crds {
-			crdMap[strings.TrimSpace(crd)] = strings.TrimSpace(crd)
-		}
-	} else {
-		isClusterScoped = util.GetClusterScope(apiExtensionClient)
-		// list the existing CRD's and convert them to map with both key and value as name
-		var crdList *apiextensions.CustomResourceDefinitionList
-		crdList, err = util.ListCustomResourceDefinitions(apiExtensionClient, "app=synopsys-operator")
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("unable to list Custom Resource Definitions due to %+v", err)
-		}
-		for _, crd := range crdList.Items {
-			crds = append(crds, crd.Name)
-			crdMap[crd.Name] = crd.Name
-		}
-	}
-	// create new Synopsys Operator SpecConfig
-	oldOperatorSpec, err := soperator.GetOldOperatorSpec(restconfig, kubeClient, namespace)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to update Synopsys Operator in '%s' namespace due to %+v", namespace, err)
-	}
-	return oldOperatorSpec, crdMap, crds, nil
-}
-
 // getUpdatedOperator returns a SpecConfig for Synopsys Operator with the updates provided by the user
-func getUpdatedOperator(oldOperatorSpec *soperator.SpecConfig, isClusterScoped bool, crdMap map[string]string, crds []string, namespace string, cmd *cobra.Command) (*soperator.SpecConfig, []string, error) {
+func getUpdatedOperator(currOperatorSpec *soperator.SpecConfig, cmd *cobra.Command) (*soperator.SpecConfig, []string, error) {
+
 	newCrds := []string{}
+	namespace := currOperatorSpec.Namespace
+
+	// convert crds to CRD map for easy comparison
+	crdMap := make(map[string]string, 0)
+	for _, crd := range currOperatorSpec.Crds {
+		crdMap[strings.TrimSpace(crd)] = strings.TrimSpace(crd)
+	}
+
+	crds := currOperatorSpec.Crds
 
 	newOperatorSpec := soperator.SpecConfig{}
 
@@ -224,7 +184,6 @@ func getUpdatedOperator(oldOperatorSpec *soperator.SpecConfig, isClusterScoped b
 		_, ok := crdMap[util.OpsSightCRDName]
 		if ok && isEnabledOpsSight {
 			log.Errorf("Custom Resource Definition '%s' already exists...", util.OpsSightCRDName)
-
 		} else if !ok && isEnabledOpsSight {
 			// create CRD
 			crds = append(crds, util.OpsSightCRDName)
@@ -244,10 +203,14 @@ func getUpdatedOperator(oldOperatorSpec *soperator.SpecConfig, isClusterScoped b
 	}
 
 	newOperatorSpec.Crds = crds
-	newOperatorSpec.IsClusterScoped = isClusterScoped
+	// HACK because of mergo merge issue
+	if len(newOperatorSpec.Crds) == 0 {
+		currOperatorSpec.Crds = newOperatorSpec.Crds
+	}
+	newOperatorSpec.IsClusterScoped = currOperatorSpec.IsClusterScoped
 
 	// merge old and new data
-	err := mergo.Merge(&newOperatorSpec, oldOperatorSpec)
+	err := mergo.Merge(&newOperatorSpec, currOperatorSpec)
 	if err != nil {
 		return nil, newCrds, fmt.Errorf("unable to merge old and new Synopsys Operator's info due to %+v", err)
 	}
@@ -277,22 +240,25 @@ var updateOperatorCmd = &cobra.Command{
 			// set existing Synopsys Operator namespace else use default
 			isClusterScoped = util.GetClusterScope(apiExtensionClient)
 			if isClusterScoped {
-				ns, err := util.GetOperatorNamespace(kubeClient, metav1.NamespaceAll)
+				namespaces, err := util.GetOperatorNamespace(kubeClient, metav1.NamespaceAll)
 				if err != nil {
 					return err
 				}
-				if metav1.NamespaceAll != ns {
-					namespace = ns
+				if len(namespaces) > 1 {
+					return fmt.Errorf("more than 1 Synopsys Operator found in your cluster. please pass the namespace of the Synopsys Operator that you want to update")
 				}
+				namespace = namespaces[0]
 			} else {
 				namespace = DefaultOperatorNamespace
 			}
 		}
-		oldOperatorSpec, crdMap, crds, err := getOperatorToUpdate(namespace, cmd)
+
+		currOperatorSpec, err := soperator.GetOldOperatorSpec(restconfig, kubeClient, namespace)
 		if err != nil {
 			return err
 		}
-		newOperatorSpec, newCrds, err := getUpdatedOperator(oldOperatorSpec, isClusterScoped, crdMap, crds, namespace, cmd)
+
+		newOperatorSpec, newCrds, err := getUpdatedOperator(currOperatorSpec, cmd)
 		if err != nil {
 			return err
 		}
@@ -306,7 +272,8 @@ var updateOperatorCmd = &cobra.Command{
 
 		log.Infof("updating Synopsys Operator in namespace '%s'...", namespace)
 		// create custom resource definitions
-		crdConfigs, err := getCrdConfigs(operatorNamespace, isClusterScoped, newCrds)
+		isClusterScoped = newOperatorSpec.IsClusterScoped
+		crdConfigs, err := getCrdConfigs(namespace, isClusterScoped, newCrds)
 		if err != nil {
 			return err
 		}
@@ -319,13 +286,13 @@ var updateOperatorCmd = &cobra.Command{
 
 		sOperatorCreater := soperator.NewCreater(false, restconfig, kubeClient)
 		// update Synopsys Operator
-		err = sOperatorCreater.EnsureSynopsysOperator(namespace, blackDuckClient, opsSightClient, alertClient, oldOperatorSpec, newOperatorSpec)
+		err = sOperatorCreater.EnsureSynopsysOperator(namespace, blackDuckClient, opsSightClient, alertClient, currOperatorSpec, newOperatorSpec)
 		if err != nil {
 			return fmt.Errorf("unable to update Synopsys Operator due to %+v", err)
 		}
 		log.Debugf("updating Prometheus in namespace '%s'", namespace)
 		// Create new Prometheus SpecConfig
-		oldPrometheusSpec, err := soperator.GetOldPrometheusSpec(restconfig, kubeClient, namespace)
+		currPrometheusSpec, err := soperator.GetOldPrometheusSpec(restconfig, kubeClient, namespace)
 		if err != nil {
 			return fmt.Errorf("error in updating Prometheus due to %+v", err)
 		}
@@ -345,7 +312,7 @@ var updateOperatorCmd = &cobra.Command{
 			newPrometheusSpec.Expose = exposeMetrics
 		}
 		// merge old and new data
-		err = mergo.Merge(&newPrometheusSpec, oldPrometheusSpec)
+		err = mergo.Merge(&newPrometheusSpec, currPrometheusSpec)
 		if err != nil {
 			return fmt.Errorf("unable to merge old and new Prometheus' info due to %+v", err)
 		}
@@ -380,22 +347,25 @@ var updateOperatorNativeCmd = &cobra.Command{
 			// set existing Synopsys Operator namespace else use default
 			isClusterScoped = util.GetClusterScope(apiExtensionClient)
 			if isClusterScoped {
-				ns, err := util.GetOperatorNamespace(kubeClient, metav1.NamespaceAll)
+				namespaces, err := util.GetOperatorNamespace(kubeClient, metav1.NamespaceAll)
 				if err != nil {
 					return err
 				}
-				if metav1.NamespaceAll != ns {
-					namespace = ns
+				if len(namespaces) > 1 {
+					return fmt.Errorf("more than 1 Synopsys Operator found in your cluster. please pass the namespace of the Synopsys Operator that you want to update")
 				}
+				namespace = namespaces[0]
 			} else {
 				namespace = DefaultOperatorNamespace
 			}
 		}
-		oldOperatorSpec, crdMap, crds, err := getOperatorToUpdate(namespace, cmd)
+
+		currOperatorSpec, err := soperator.GetOldOperatorSpec(restconfig, kubeClient, namespace)
 		if err != nil {
 			return err
 		}
-		newOperatorSpec, _, err := getUpdatedOperator(oldOperatorSpec, isClusterScoped, crdMap, crds, namespace, cmd)
+
+		newOperatorSpec, _, err := getUpdatedOperator(currOperatorSpec, cmd)
 		if err != nil {
 			return err
 		}
@@ -456,7 +426,7 @@ var updateAlertCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mockMode := cmd.Flags().Lookup("mock").Changed
-		alertName, alertNamespace, _, err := getInstanceInfo(false, args[0], util.AlertCRDName, util.AlertName, namespace)
+		alertName, alertNamespace, _, err := getInstanceInfo(false, util.AlertCRDName, util.AlertName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -506,7 +476,7 @@ var updateAlertNativeCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		alertName, alertNamespace, _, err := getInstanceInfo(false, args[0], util.AlertCRDName, util.AlertName, namespace)
+		alertName, alertNamespace, _, err := getInstanceInfo(false, util.AlertCRDName, util.AlertName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -576,7 +546,7 @@ var updateBlackDuckCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mockMode := cmd.Flags().Lookup("mock").Changed
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -616,7 +586,6 @@ var updateBlackDuckNativeCmd = &cobra.Command{
 	Use:           "native NAME",
 	Example:       "synopsyctl update blackduck native <name> --size medium\nsynopsyctl update blackduck native <name> -n <namespace> --size medium\nsynopsyctl update blackduck native <name> --size medium -o yaml",
 	Short:         "Print the Kubernetes resources with updates to a Black Duck instance",
-	Aliases:       []string{"bds", "bd"},
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -626,7 +595,7 @@ var updateBlackDuckNativeCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -671,14 +640,9 @@ var updateBlackDuckRootKeyCmd = &cobra.Command{
 			return fmt.Errorf("must provide a namespace to update the Black Duck instance")
 		}
 
-		var operatorNamespace string
-		if crdScope == apiextensions.ClusterScoped {
-			operatorNamespace, err = getOperatorNamespace(metav1.NamespaceAll)
-			if err != nil {
-				return fmt.Errorf("unable to find the Synopsys Operator instance due to %+v", err)
-			}
-		} else {
-			operatorNamespace = namespace
+		operatorNamespace, err := util.GetOperatorNamespaceByCRDScope(kubeClient, util.BlackDuckCRDName, crdScope, namespace)
+		if err != nil {
+			return fmt.Errorf("unable to find the Synopsys Operator instance due to %+v", err)
 		}
 
 		newSealKey := args[0]
@@ -754,7 +718,7 @@ var updateBlackDuckAddEnvironCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mockMode := cmd.Flags().Lookup("mock").Changed
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -798,7 +762,7 @@ var updateBlackDuckAddEnvironNativeCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -857,7 +821,7 @@ var updateBlackDuckSetImageRegistryCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mockMode := cmd.Flags().Lookup("mock").Changed
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -901,7 +865,7 @@ var updateBlackDuckSetImageRegistryNativeCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, args[0], util.BlackDuckCRDName, util.BlackDuckName, namespace)
+		blackDuckName, blackDuckNamespace, _, err := getInstanceInfo(false, util.BlackDuckCRDName, util.BlackDuckName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -967,7 +931,7 @@ var updateOpsSightCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mockMode := cmd.Flags().Lookup("mock").Changed
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -1008,7 +972,6 @@ var updateOpsSightNativeCmd = &cobra.Command{
 	Use:           "native NAME",
 	Example:       "synopsyctl update opssight native <name> --blackduck-max-count 2\nsynopsyctl update opssight native <name> --blackduck-max-count 2 -n <namespace>\nsynopsyctl update opssight native <name> --blackduck-max-count 2 -o yaml",
 	Short:         "Print the Kubernetes resources with updates to an OpsSight instance",
-	Aliases:       []string{"ops"},
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
@@ -1019,7 +982,7 @@ var updateOpsSightNativeCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -1073,7 +1036,7 @@ var updateOpsSightImageCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mockMode := cmd.Flags().Lookup("mock").Changed
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -1117,7 +1080,7 @@ var updateOpsSightImageNativeCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -1182,7 +1145,7 @@ var updateOpsSightExternalHostCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mockMode := cmd.Flags().Lookup("mock").Changed
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -1236,7 +1199,7 @@ var updateOpsSightExternalHostNativeCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -1280,7 +1243,7 @@ var updateOpsSightAddRegistryCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		mockMode := cmd.Flags().Lookup("mock").Changed
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}
@@ -1324,7 +1287,7 @@ var updateOpsSightAddRegistryNativeCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, args[0], util.OpsSightCRDName, util.OpsSightName, namespace)
+		opsSightName, opsSightNamespace, _, err := getInstanceInfo(false, util.OpsSightCRDName, util.OpsSightName, namespace, args[0])
 		if err != nil {
 			return err
 		}

--- a/pkg/util/crd_defaults.go
+++ b/pkg/util/crd_defaults.go
@@ -456,7 +456,7 @@ func GetOpsSightDefault() *opssightv1.OpsSightSpec {
 	return &opssightv1.OpsSightSpec{
 		Namespace: "opssight-test",
 		Perceptor: &opssightv1.Perceptor{
-			Name:                           "opssight-core",
+			Name:                           "core",
 			Port:                           3001,
 			Image:                          "docker.io/blackducksoftware/opssight-core:2.2.3",
 			CheckForStalledScansPauseHours: 999999,
@@ -467,19 +467,19 @@ func GetOpsSightDefault() *opssightv1.OpsSightSpec {
 			Expose:                         NONE,
 		},
 		ScannerPod: &opssightv1.ScannerPod{
-			Name: "opssight-scanner",
+			Name: "scanner",
 			Scanner: &opssightv1.Scanner{
-				Name:                 "opssight-scanner",
+				Name:                 "scanner",
 				Port:                 3003,
 				Image:                "docker.io/blackducksoftware/opssight-scanner:2.2.3",
 				ClientTimeoutSeconds: 600,
 			},
 			ImageFacade: &opssightv1.ImageFacade{
-				Name:               "opssight-image-getter",
+				Name:               "image-getter",
 				Port:               3004,
 				InternalRegistries: []*opssightv1.RegistryAuth{},
 				Image:              "docker.io/blackducksoftware/opssight-image-getter:2.2.3",
-				ServiceAccount:     "opssight-scanner",
+				ServiceAccount:     "scanner",
 				ImagePullerType:    "skopeo",
 			},
 			ReplicaCount: 1,
@@ -489,14 +489,14 @@ func GetOpsSightDefault() *opssightv1.OpsSightSpec {
 			EnablePodPerceiver:   false,
 			Port:                 3002,
 			ImagePerceiver: &opssightv1.ImagePerceiver{
-				Name:  "opssight-image-processor",
+				Name:  "image-processor",
 				Image: "docker.io/blackducksoftware/opssight-image-processor:2.2.3",
 			},
 			PodPerceiver: &opssightv1.PodPerceiver{
-				Name:  "opssight-pod-processor",
+				Name:  "pod-processor",
 				Image: "docker.io/blackducksoftware/opssight-pod-processor:2.2.3",
 			},
-			ServiceAccount:            "opssight-processor",
+			ServiceAccount:            "processor",
 			AnnotationIntervalSeconds: 30,
 			DumpIntervalMinutes:       30,
 		},
@@ -543,7 +543,7 @@ func GetOpsSightDefaultWithIPV6DisabledBlackDuck() *opssightv1.OpsSightSpec {
 	return &opssightv1.OpsSightSpec{
 		Namespace: "opssight-test",
 		Perceptor: &opssightv1.Perceptor{
-			Name:                           "opssight-core",
+			Name:                           "core",
 			Port:                           3001,
 			Image:                          "docker.io/blackducksoftware/opssight-core:2.2.3",
 			CheckForStalledScansPauseHours: 999999,
@@ -554,19 +554,19 @@ func GetOpsSightDefaultWithIPV6DisabledBlackDuck() *opssightv1.OpsSightSpec {
 			Expose:                         NONE,
 		},
 		ScannerPod: &opssightv1.ScannerPod{
-			Name: "opssight-scanner",
+			Name: "scanner",
 			Scanner: &opssightv1.Scanner{
-				Name:                 "opssight-scanner",
+				Name:                 "scanner",
 				Port:                 3003,
 				Image:                "docker.io/blackducksoftware/opssight-scanner:2.2.3",
 				ClientTimeoutSeconds: 600,
 			},
 			ImageFacade: &opssightv1.ImageFacade{
-				Name:               "opssight-image-getter",
+				Name:               "image-getter",
 				Port:               3004,
 				InternalRegistries: []*opssightv1.RegistryAuth{},
 				Image:              "docker.io/blackducksoftware/opssight-image-getter:2.2.3",
-				ServiceAccount:     "opssight-scanner",
+				ServiceAccount:     "scanner",
 				ImagePullerType:    "skopeo",
 			},
 			ReplicaCount: 1,
@@ -575,11 +575,11 @@ func GetOpsSightDefaultWithIPV6DisabledBlackDuck() *opssightv1.OpsSightSpec {
 			EnableImagePerceiver: false,
 			EnablePodPerceiver:   true,
 			ImagePerceiver: &opssightv1.ImagePerceiver{
-				Name:  "opssight-image-processor",
+				Name:  "image-processor",
 				Image: "docker.io/blackducksoftware/opssight-image-processor:2.2.3",
 			},
 			PodPerceiver: &opssightv1.PodPerceiver{
-				Name:  "opssight-pod-processor",
+				Name:  "pod-processor",
 				Image: "docker.io/blackducksoftware/opssight-pod-processor:2.2.3",
 			},
 			ServiceAccount:            "opssight-processor",


### PR DESCRIPTION
* delete Black Duck not removing the labels from namespace
* destroy operator creating namespace
* removal of create namespace logic and use operator namespace
* update resources not finding the namespace automatically
* removed the incorrect alias for Black Duck native command
* OpsSight labels to be consistent with others

TODO: removal of namespace creation will be in separate PR

fixes #550