### PR TITLE
remove examples of opssight in namespaced mode

### DIFF
--- a/pkg/synopsysctl/cmd_create.go
+++ b/pkg/synopsysctl/cmd_create.go
@@ -441,7 +441,7 @@ func updateOpsSightSpecWithFlags(cmd *cobra.Command, opsSightName string, opsSig
 // createOpsSightCmd creates an OpsSight instance
 var createOpsSightCmd = &cobra.Command{
 	Use:           "opssight NAME",
-	Example:       "synopsysctl create opssight <name>\nsynopsysctl create opssight <name> -n <namespace>\nsynopsysctl create opssight <name> --mock json",
+	Example:       "synopsysctl create opssight <name>\nsynopsysctl create opssight <name> --mock json",
 	Short:         "Create an OpsSight instance",
 	Aliases:       []string{"ops"},
 	SilenceUsage:  true,
@@ -490,7 +490,7 @@ var createOpsSightCmd = &cobra.Command{
 // createOpsSightNativeCmd prints the Kubernetes resources for creating an OpsSight instance
 var createOpsSightNativeCmd = &cobra.Command{
 	Use:           "native NAME",
-	Example:       "synopsysctl create opssight native <name>\nsynopsysctl create opssight native <name> -n <namespace>\nsynopsysctl create opssight native <name> -o yaml",
+	Example:       "synopsysctl create opssight native <name>\nsynopsysctl create opssight native <name> -o yaml",
 	Short:         "Print the Kubernetes resources for creating an OpsSight instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/pkg/synopsysctl/cmd_delete.go
+++ b/pkg/synopsysctl/cmd_delete.go
@@ -105,7 +105,7 @@ var deleteBlackDuckCmd = &cobra.Command{
 // deleteOpsSightCmd deletes OpsSight instances from the cluster
 var deleteOpsSightCmd = &cobra.Command{
 	Use:           "opssight NAME...",
-	Example:       "synopsysctl delete opssight <name>\nsynopsysctl delete opssight <name1> <name2> <name3>\nsynopsysctl delete opssight <name> -n <namespace>\nsynopsysctl delete opssight <name1> <name2> <name3> -n <namespace>",
+	Example:       "synopsysctl delete opssight <name>\nsynopsysctl delete opssight <name1> <name2> <name3>",
 	Short:         "Delete one or many OpsSight instances",
 	Aliases:       []string{"ops"},
 	SilenceUsage:  true,

--- a/pkg/synopsysctl/cmd_describe.go
+++ b/pkg/synopsysctl/cmd_describe.go
@@ -109,7 +109,7 @@ var describeBlackDuckCmd = &cobra.Command{
 // describeOpsSightCmd shows details of one or many OpsSight instances
 var describeOpsSightCmd = &cobra.Command{
 	Use:           "opssight [NAME...]",
-	Example:       "synopsysctl describe opssights\nsynopsysctl describe opssight <name>\nsynopsysctl describe opssights <name1> <name2>\nsynopsysctl describe opssights -n <namespace>\nsynopsysctl describe opssight <name> -n <namespace>\nsynopsysctl describe opssights <name1> <name2> -n <namespace>",
+	Example:       "synopsysctl describe opssights\nsynopsysctl describe opssight <name>\nsynopsysctl describe opssights <name1> <name2>",
 	Aliases:       []string{"opssights", "ops"},
 	Short:         "Show details of one or many OpsSight instances",
 	SilenceUsage:  true,

--- a/pkg/synopsysctl/cmd_edit.go
+++ b/pkg/synopsysctl/cmd_edit.go
@@ -100,7 +100,7 @@ var editBlackDuckCmd = &cobra.Command{
 // editOpsSightCmd edits an OpsSight instance by using the kube/oc editor
 var editOpsSightCmd = &cobra.Command{
 	Use:           "opssight NAME",
-	Example:       "synopsysctl edit opssight <name>\nsynopsysctl edit opssight <name> -n <namespace>",
+	Example:       "synopsysctl edit opssight <name>",
 	Short:         "Edit an OpsSight instance",
 	Aliases:       []string{"ops"},
 	SilenceUsage:  true,

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -917,7 +917,7 @@ func updateOpsSight(ops *opssightapi.OpsSight, flagset *pflag.FlagSet) (*opssigh
 // updateOpsSightCmd updates an OpsSight instance
 var updateOpsSightCmd = &cobra.Command{
 	Use:           "opssight NAME",
-	Example:       "synopsyctl update opssight <name> --blackduck-max-count 2\nsynopsyctl update opssight <name> --blackduck-max-count 2 -n <namespace>\nsynopsyctl update opssight <name> --blackduck-max-count 2 --mock json",
+	Example:       "synopsyctl update opssight <name> --blackduck-max-count 2\nsynopsyctl update opssight <name> --blackduck-max-count 2 --mock json",
 	Short:         "Update an OpsSight instance",
 	Aliases:       []string{"ops"},
 	SilenceUsage:  true,
@@ -970,7 +970,7 @@ var updateOpsSightCmd = &cobra.Command{
 // updateOpsSightNativeCmd prints the Kubernetes resources with updates to an OpsSight instance
 var updateOpsSightNativeCmd = &cobra.Command{
 	Use:           "native NAME",
-	Example:       "synopsyctl update opssight native <name> --blackduck-max-count 2\nsynopsyctl update opssight native <name> --blackduck-max-count 2 -n <namespace>\nsynopsyctl update opssight native <name> --blackduck-max-count 2 -o yaml",
+	Example:       "synopsyctl update opssight native <name> --blackduck-max-count 2\nsynopsyctl update opssight native <name> --blackduck-max-count 2 -o yaml",
 	Short:         "Print the Kubernetes resources with updates to an OpsSight instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -1023,7 +1023,7 @@ func updateOpsSightImage(ops *opssightapi.OpsSight, imageName, image string) (*o
 // updateOpsSightImageCmd updates an image of an OpsSight instance's component
 var updateOpsSightImageCmd = &cobra.Command{
 	Use:           "image NAME OPSSIGHTCORE|SCANNER|IMAGEGETTER|IMAGEPROCESSOR|PODPROCESSOR|METRICS IMAGE",
-	Example:       "synopsysctl update opssight image <name> SCANNER docker.io/new_scanner_image_url\nsynopsysctl update opssight image <name> SCANNER docker.io/new_scanner_image_url -n <namespace>",
+	Example:       "synopsysctl update opssight image <name> SCANNER docker.io/new_scanner_image_url",
 	Short:         "Update an image of an OpsSight instance's component",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -1068,7 +1068,7 @@ var updateOpsSightImageCmd = &cobra.Command{
 // updateOpsSightImageNativeCmd prints the Kuberntes resources with updates to an image of an OpsSight instance's component
 var updateOpsSightImageNativeCmd = &cobra.Command{
 	Use:           "native NAME OPSSIGHTCORE|SCANNER|IMAGEGETTER|IMAGEPROCESSOR|PODPROCESSOR|METRICS IMAGE",
-	Example:       "synopsysctl update opssight image native <name> SCANNER docker.io/new_scanner_image_url\nsynopsysctl update opssight image native <name> SCANNER docker.io/new_scanner_image_url -n <namespace>",
+	Example:       "synopsysctl update opssight image native <name> SCANNER docker.io/new_scanner_image_url",
 	Short:         "Print the Kuberntes resources with updates to an image of an OpsSight instance's component",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -1122,7 +1122,7 @@ func updateOpsSightExternalHost(ops *opssightapi.OpsSight, scheme, domain, port,
 // updateOpsSightExternalHostCmd updates an external host for an OpsSight intance's component
 var updateOpsSightExternalHostCmd = &cobra.Command{
 	Use:           "externalhost NAME SCHEME DOMAIN PORT USER PASSWORD SCANLIMIT",
-	Example:       "synopsysctl update opssight externalhost <name> scheme domain 80 user pass 50\nsynopsysctl update opssight externalhost <name> scheme domain 80 user pass 50 -n <namespace>",
+	Example:       "synopsysctl update opssight externalhost <name> scheme domain 80 user pass 50",
 	Short:         "Update an external host for an OpsSight intance's component",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -1177,7 +1177,7 @@ var updateOpsSightExternalHostCmd = &cobra.Command{
 // updateOpsSightExternalHostNativeCmd prints the Kubernetes resources with updates to an external host for an OpsSight intance's component
 var updateOpsSightExternalHostNativeCmd = &cobra.Command{
 	Use:           "externalhost NAME SCHEME DOMAIN PORT USER PASSWORD SCANLIMIT",
-	Example:       "synopsysctl update opssight externalhost native <name> scheme domain 80 user pass 50\nsynopsysctl update opssight externalhost native <name> scheme domain 80 user pass 50 -n <namespace>",
+	Example:       "synopsysctl update opssight externalhost native <name> scheme domain 80 user pass 50",
 	Short:         "Print the Kubernetes resources with updates to an external host for an OpsSight intance's component",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -1230,7 +1230,7 @@ func updateOpsSightAddRegistry(ops *opssightapi.OpsSight, url, user, pass string
 // updateOpsSightAddRegistryCmd adds an internal registry to an OpsSight instance's ImageFacade
 var updateOpsSightAddRegistryCmd = &cobra.Command{
 	Use:           "registry NAME URL USER PASSWORD",
-	Example:       "synopsysctl update opssight registry <name> reg_url reg_username reg_password\nsynopsysctl update opssight registry <name> reg_url reg_username reg_password -n <namespace>",
+	Example:       "synopsysctl update opssight registry <name> reg_url reg_username reg_password",
 	Short:         "Add an internal registry to an OpsSight instance's ImageFacade",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -1275,7 +1275,7 @@ var updateOpsSightAddRegistryCmd = &cobra.Command{
 // updateOpsSightAddRegistryNativeCmd prints the Kubernetes resources with updates from adding an internal registry to an OpsSight instance's ImageFacade
 var updateOpsSightAddRegistryNativeCmd = &cobra.Command{
 	Use:           "native NAME URL USER PASSWORD",
-	Example:       "synopsysctl update opssight registry native <name> reg_url reg_username reg_password\nsynopsysctl update opssight registry native <name> reg_url reg_username reg_password -n <namespace>",
+	Example:       "synopsysctl update opssight registry native <name> reg_url reg_username reg_password",
 	Short:         "Print the Kubernetes resources with updates from adding an internal registry to an OpsSight instance's ImageFacade",
 	SilenceUsage:  true,
 	SilenceErrors: true,


### PR DESCRIPTION
I think it's confusing to show examples of OpsSight in namespaced mode if we do not support this situation. We could consider removing the namespace flag for OpsSight too. 