### PR TITLE
Support openshift 4.1

### DIFF
--- a/cmd/operator/run.go
+++ b/cmd/operator/run.go
@@ -65,15 +65,7 @@ func runProtoform(configPath string, version string) {
 		log.Infof("Kubernetes: %s", kversion)
 	}
 
-	// Log Openshift version
-	oversion, err := util.GetOcVersion(deployer.KubeClientSet)
-	if err == nil {
-		log.Infof("Openshift: %s", oversion)
-	}
-
-	if len(oversion) > 0 {
-		deployer.Config.IsOpenshift = true
-	}
+	deployer.Config.IsOpenshift = util.IsOpenshift(deployer.KubeClientSet)
 
 	stopCh := make(chan struct{})
 

--- a/pkg/alert/crdinstaller.go
+++ b/pkg/alert/crdinstaller.go
@@ -137,15 +137,15 @@ func (c *CRDInstaller) AddInformerEventHandler() {
 
 // CreateHandler will create a CRD handler
 func (c *CRDInstaller) CreateHandler() {
-	routeClient := util.GetRouteClient(c.kubeConfig, c.kubeClient, c.config.Namespace)
-
 	c.handler = &Handler{
 		config:      c.config,
 		kubeConfig:  c.kubeConfig,
 		kubeClient:  c.kubeClient,
 		alertClient: c.alertClient,
 		defaults:    c.defaults.(*alertapi.AlertSpec),
-		routeClient: routeClient,
+	}
+	if util.IsOpenshift(c.kubeClient) {
+		c.handler.routeClient = util.GetRouteClient(c.kubeConfig, c.kubeClient, c.config.Namespace)
 	}
 }
 

--- a/pkg/apps/blackduck/blackduck.go
+++ b/pkg/apps/blackduck/blackduck.go
@@ -71,7 +71,10 @@ func NewBlackduck(config *protoform.Config, kubeConfig *rest.Config) *Blackduck 
 		return nil
 	}
 
-	routeClient := util.GetRouteClient(kubeConfig, kubeclient, config.Namespace)
+	var routeClient *routeclient.RouteV1Client
+	if util.IsOpenshift(kubeclient) {
+		routeClient = util.GetRouteClient(kubeConfig, kubeclient, config.Namespace)
+	}
 
 	creaters := []Creater{
 		v1blackduck.NewCreater(config, kubeConfig, kubeclient, blackduckClient, routeClient),

--- a/pkg/blackduck/crdinstaller.go
+++ b/pkg/blackduck/crdinstaller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	"github.com/juju/errors"
+	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -182,7 +183,10 @@ func (c *CRDInstaller) AddInformerEventHandler() {
 
 // CreateHandler will create a CRD handler
 func (c *CRDInstaller) CreateHandler() {
-	routeClient := util.GetRouteClient(c.kubeConfig, c.kubeClient, c.config.Namespace)
+	var routeClient *routeclient.RouteV1Client
+	if util.IsOpenshift(c.kubeClient) {
+		routeClient = util.GetRouteClient(c.kubeConfig, c.kubeClient, c.config.Namespace)
+	}
 	c.handler = NewHandler(c.config, c.kubeConfig, c.kubeClient, c.hubClient, c.defaults.(*v1.BlackduckSpec), make(chan bool, 1), nil, routeClient)
 }
 

--- a/pkg/crdupdater/route.go
+++ b/pkg/crdupdater/route.go
@@ -42,10 +42,11 @@ type Route struct {
 
 // NewRoute returns the route configuration
 func NewRoute(config *CommonConfig, routes []*api.Route) (*Route, error) {
-	routeClient := util.GetRouteClient(config.kubeConfig, config.kubeClient, config.namespace)
-	if routeClient == nil { // skip if running Kubernetes
+	if !util.IsOpenshift(config.kubeClient) {
 		return nil, nil
 	}
+	routeClient := util.GetRouteClient(config.kubeConfig, config.kubeClient, config.namespace)
+
 	deployer, err := util.NewDeployer(config.kubeConfig)
 	if err != nil {
 		return nil, errors.Annotatef(err, "unable to get deployer object for %s", config.namespace)

--- a/pkg/opssight/crdinstaller.go
+++ b/pkg/opssight/crdinstaller.go
@@ -169,8 +169,6 @@ func (c *CRDInstaller) CreateHandler() {
 		}
 	}
 
-	routeClient := util.GetRouteClient(c.kubeConfig, c.kubeClient, c.config.Namespace)
-
 	hubClient, err := hubclient.NewForConfig(c.kubeConfig)
 	if err != nil {
 		log.Errorf("unable to create the hub client for opssight: %+v", err)
@@ -184,9 +182,12 @@ func (c *CRDInstaller) CreateHandler() {
 		OpsSightClient:   c.opssightclient,
 		Namespace:        c.config.Namespace,
 		OSSecurityClient: osClient,
-		RouteClient:      routeClient,
 		Defaults:         c.defaults.(*opssightapi.OpsSightSpec),
 		HubClient:        hubClient,
+	}
+
+	if util.IsOpenshift(c.kubeClient) {
+		c.handler.RouteClient = util.GetRouteClient(c.kubeConfig, c.kubeClient, c.config.Namespace)
 	}
 }
 

--- a/pkg/soperator/soperator_creater.go
+++ b/pkg/soperator/soperator_creater.go
@@ -138,7 +138,7 @@ func (sc *Creater) EnsureSynopsysOperator(namespace string, blackduckClient *bla
 
 	// Update the Synopsys Operator's Components
 	log.Debugf("updating Synopsys Operator's Components")
-	newOperatorSpec.ClusterType = GetClusterType(sc.KubeConfig, sc.KubeClient, namespace)
+	newOperatorSpec.ClusterType = GetClusterType(sc.KubeClient)
 	err = sc.UpdateSOperatorComponents(newOperatorSpec)
 	if err != nil {
 		return fmt.Errorf("failed to update Synopsys Operator components: %s", err)

--- a/pkg/soperator/utils.go
+++ b/pkg/soperator/utils.go
@@ -189,12 +189,9 @@ func GetOldPrometheusSpec(restConfig *rest.Config, kubeClient *kubernetes.Client
 }
 
 // GetClusterType returns the Cluster type. It defaults to Kubernetes
-func GetClusterType(restConfig *rest.Config, kubeClient *kubernetes.Clientset, namespace string) ClusterType {
-	if restConfig != nil && kubeClient != nil {
-		routeClient := util.GetRouteClient(restConfig, kubeClient, namespace)
-		if routeClient != nil {
-			return OpenshiftClusterType
-		}
+func GetClusterType(kubeClient *kubernetes.Clientset) ClusterType {
+	if util.IsOpenshift(kubeClient) {
+		return OpenshiftClusterType
 	}
 	return KubernetesClusterType
 }

--- a/pkg/synopsysctl/cmd_deploy.go
+++ b/pkg/synopsysctl/cmd_deploy.go
@@ -228,7 +228,7 @@ func getSpecToDeploySOperator(crds []string) (*soperator.SpecConfig, error) {
 	}
 	// Deploy Synopsys Operator
 	log.Debugf("creating Synopsys Operator's components")
-	soperatorSpec := soperator.NewSOperator(operatorNamespace, synopsysOperatorImage, exposeUI, soperator.GetClusterType(restconfig, kubeClient, operatorNamespace),
+	soperatorSpec := soperator.NewSOperator(operatorNamespace, synopsysOperatorImage, exposeUI, soperator.GetClusterType(kubeClient),
 		strings.ToUpper(dryRun) == "TRUE", logLevel, threadiness, postgresRestartInMins, podWaitTimeoutSeconds, resyncIntervalInSeconds,
 		terminationGracePeriodSeconds, sealKey, restconfig, kubeClient, cert, key, isClusterScoped, crds, admissionWebhookListener)
 	return soperatorSpec, nil

--- a/pkg/synopsysctl/cmd_migrate.go
+++ b/pkg/synopsysctl/cmd_migrate.go
@@ -748,20 +748,22 @@ func addNameLabels(namespace string, name string, appName string) error {
 		}
 	}
 
-	routeClient := util.GetRouteClient(restconfig, kubeClient, namespace)
-	if routeClient != nil {
-		routes, err := util.ListRoutes(routeClient, namespace, fmt.Sprintf("app=%s", appName))
-		if err != nil {
-			return fmt.Errorf("unable to list routes for %s %s in namespace %s due to %+v", appName, name, namespace, err)
-		}
+	if util.IsOpenshift(kubeClient) {
+		routeClient := util.GetRouteClient(restconfig, kubeClient, namespace)
+		if routeClient != nil {
+			routes, err := util.ListRoutes(routeClient, namespace, fmt.Sprintf("app=%s", appName))
+			if err != nil {
+				return fmt.Errorf("unable to list routes for %s %s in namespace %s due to %+v", appName, name, namespace, err)
+			}
 
-		for _, route := range routes.Items {
-			if _, ok := route.Labels["name"]; !ok || appName == util.OpsSightName {
-				route.Labels = util.InitLabels(route.Labels)
-				route.Labels["name"] = name
-				_, err = util.UpdateRoute(routeClient, namespace, &route)
-				if err != nil {
-					return fmt.Errorf("unable to update %s route in namespace %s due to %+v", route.GetName(), namespace, err)
+			for _, route := range routes.Items {
+				if _, ok := route.Labels["name"]; !ok || appName == util.OpsSightName {
+					route.Labels = util.InitLabels(route.Labels)
+					route.Labels["name"] = name
+					_, err = util.UpdateRoute(routeClient, namespace, &route)
+					if err != nil {
+						return fmt.Errorf("unable to update %s route in namespace %s due to %+v", route.GetName(), namespace, err)
+					}
 				}
 			}
 		}

--- a/pkg/synopsysctl/utils.go
+++ b/pkg/synopsysctl/utils.go
@@ -30,13 +30,11 @@ import (
 	blackduckclientset "github.com/blackducksoftware/synopsys-operator/pkg/blackduck/client/clientset/versioned"
 	opssightclientset "github.com/blackducksoftware/synopsys-operator/pkg/opssight/client/clientset/versioned"
 	"github.com/blackducksoftware/synopsys-operator/pkg/protoform"
-	operatorutil "github.com/blackducksoftware/synopsys-operator/pkg/util"
-	util "github.com/blackducksoftware/synopsys-operator/pkg/util"
+	"github.com/blackducksoftware/synopsys-operator/pkg/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -133,8 +131,7 @@ func DetermineClusterClients(restConfig *rest.Config, kubeClient *kubernetes.Cli
 
 	// Add Openshift rules
 	openshiftTest := false
-	routeClient := operatorutil.GetRouteClient(restConfig, kubeClient, metav1.NamespaceAll) // kube doesn't have a route client but openshift does
-	if routeClient != nil {
+	if util.IsOpenshift(kubeClient) {
 		openshiftTest = true
 	}
 

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -57,7 +57,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -1085,22 +1084,10 @@ func DeleteRoleBinding(clientset *kubernetes.Clientset, namespace string, name s
 // fails due to an error or due to being on kubernetes (doesn't support routes)
 func GetRouteClient(restConfig *rest.Config, clientset *kubernetes.Clientset, namespace string) *routeclient.RouteV1Client {
 	routeClient, err := routeclient.NewForConfig(restConfig)
-	if routeClient == nil || err != nil {
+	if err != nil {
 		return nil
 	}
-
-	ocVersion, err := GetOcVersion(clientset)
-	if err == nil && len(ocVersion) > 0 {
-		return routeClient
-	}
-
-	// if not within container, check using list routes to determine whether it is an OpenShift cluster
-	_, err = ListRoutes(routeClient, namespace, "")
-	if err == nil {
-		return routeClient
-	}
-
-	return nil
+	return routeClient
 }
 
 // GetRoute gets an OpenShift routes
@@ -1552,20 +1539,14 @@ func GetKubernetesVersion(clientset *kubernetes.Clientset) (string, error) {
 	return "", err
 }
 
-// GetOcVersion will return the version of openshift
-func GetOcVersion(clientset *kubernetes.Clientset) (string, error) {
-	body, err := clientset.Discovery().RESTClient().Get().AbsPath("/version/openshift").Do().Raw()
+// IsOpenshift will whether it is an openshift cluster
+func IsOpenshift(clientset *kubernetes.Clientset) bool {
+	body, err := clientset.Discovery().RESTClient().Get().AbsPath("/").Do().Raw()
 	if err != nil {
-		return "", err
+		return false
 	}
 
-	var info version.Info
-	err = json.Unmarshal(body, &info)
-	if err != nil {
-		return "", fmt.Errorf("unable to parse the server version: %v", err)
-	}
-
-	return info.GitVersion, err
+	return strings.Contains(string(body), "openshift")
 }
 
 // IsOperatorExist returns whether the operator exist or not


### PR DESCRIPTION
Openshift removed the `/version/openshift` endpoint in version 4.1 and therefore, we need to change our method to determine the cluster type.