### PR TITLE
Fix blackduck registration

### DIFF
--- a/pkg/apps/blackduck/latest/creater.go
+++ b/pkg/apps/blackduck/latest/creater.go
@@ -357,7 +357,7 @@ func (hc *Creater) autoRegisterHub(name string, bdspec *blackduckapi.BlackduckSp
 			}
 
 			// Create the exec into Kubernetes pod request
-			req := util.CreateExecContainerRequest(hc.kubeClient, registrationPod, "/bin/bash")
+			req := util.CreateExecContainerRequest(hc.kubeClient, registrationPod, "/bin/sh")
 			// Exec into the Kubernetes pod and execute the commands
 			_, err = util.ExecContainer(hc.kubeConfig, req, []string{fmt.Sprintf(`curl -k -X POST "https://127.0.0.1:8443/registration/HubRegistration?registrationid=%s&action=activate" -k --cert /opt/blackduck/hub/hub-registration/security/blackduck_system.crt --key /opt/blackduck/hub/hub-registration/security/blackduck_system.key`, registrationKey)})
 


### PR DESCRIPTION
`/bin/bash` is no longer in the blackduck-registration container and therefore, we need to start using `/bin/sh`