### PR TITLE
moved smtp sender email regex replacement to PolarisMutator.go

### DIFF
--- a/pkg/polaris/polarisDBMutator.go
+++ b/pkg/polaris/polarisDBMutator.go
@@ -63,7 +63,6 @@ func GetPolarisDBComponents(baseURL string, polaris Polaris) (map[string]runtime
 	} else {
 		content = strings.ReplaceAll(content, "${SMTP_PASSWORD}", "Cg==")
 	}
-	content = strings.ReplaceAll(content, "${SMTP_SENDER_EMAIL}", polaris.PolarisDBSpec.SMTPDetails.SenderEmail)
 	content = strings.ReplaceAll(content, "${POSTGRES_HOST}", polaris.PolarisDBSpec.PostgresDetails.Host)
 	if polaris.PolarisDBSpec.PostgresDetails.Port != 5432 {
 		content = strings.ReplaceAll(content, "5432", strconv.Itoa(polaris.PolarisDBSpec.PostgresDetails.Port))

--- a/pkg/polaris/polarisMutator.go
+++ b/pkg/polaris/polarisMutator.go
@@ -60,6 +60,8 @@ func GetPolarisComponents(baseURL string, polaris Polaris) (map[string]runtime.O
 		content = strings.ReplaceAll(content, "gcr.io/snps-swip-staging", polaris.Repository)
 	}
 
+	content = strings.ReplaceAll(content, "${SMTP_SENDER_EMAIL}", polaris.PolarisDBSpec.SMTPDetails.SenderEmail)
+
 	mapOfUniqueIDToBaseRuntimeObject := ConvertYamlFileToRuntimeObjects(content)
 	mapOfUniqueIDToBaseRuntimeObject = removeTestManifests(mapOfUniqueIDToBaseRuntimeObject)
 


### PR DESCRIPTION
Moved SMTP_SENDER_EMAIL regex replacement to `PolarisMutator.go`, because only the polaris_base.yaml will have references to it.