### PR TITLE
Update Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,40 @@
-FROM gobuffalo/buffalo:v0.14.3 as builder
+# Run: "docker run --rm -i hadolint/hadolint < Dockerfile" to ensure best practices!
 
 ARG BINARY_VERSION
 
-# Set the environment
+# [STAGE: BUILD OPERATOR]
+FROM golang:1.13-alpine as operatorbuilder
+
+ENV BP=$GOPATH/src/github.com/blackducksoftware/synopsys-operator
+
+# Add the whole Synopsys Operator repository
+COPY . ${BP}
+
+# Container catalog requirements
+COPY ./LICENSE /bin/LICENSE
+COPY ./help.1 /bin/help.1
+
+# Build the Synopsys Operator binary
+WORKDIR ${BP}/cmd/operator
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$BINARY_VERSION" -o /bin/operator
+
+# [STAGE: BUILD OPERATOR-UI]
+
+FROM gobuffalo/buffalo:v0.15.0 as operatoruibuilder
+
 ENV GO111MODULE=on
 ENV BUFFALO_PLUGIN_CACHE=off
 ENV BP=$GOPATH/src/github.com/blackducksoftware/synopsys-operator
 
-# Add the Synopsys Operator repository
-ADD . $BP
+# Add the whole Synopsys Operator repository
+COPY . $BP
 
-# Setting the work directory
-WORKDIR $BP
+# Build the Synopsys Operator UI
+WORKDIR ${BP}/cmd/operator-ui
+RUN yarn install --no-progress && mkdir -p public/assets && buffalo build --ldflags "-X main.version=$BINARY_VERSION" --static -o /bin/app
 
-### Build the Synopsys Operator binary
-RUN cd cmd/operator && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$BINARY_VERSION" -o /bin/operator
-
-### Build the Synopsys Operator UI
-RUN cd cmd/operator-ui && yarn install --no-progress && mkdir -p public/assets && buffalo build --ldflags "-X main.version=$BINARY_VERSION" --static -o /bin/app
-
-# Container catalog requirements
-COPY ./LICENSE /bin/LICENSE 
-COPY ./help.1 /bin/help.1
-
+# [FINAL STAGE]
 FROM scratch
-
-MAINTAINER Synopsys Cloud Native Team
 
 ARG VERSION
 ARG BUILDTIME
@@ -41,12 +50,14 @@ ARG LASTCOMMIT
 # Bind the app to 0.0.0.0 so it can be seen from outside the container
 # ENV ADDR=0.0.0.0
 
-COPY --from=builder /bin/app .
-COPY --from=builder /bin/operator .
-COPY --from=builder /bin/LICENSE /licenses/
-COPY --from=builder /bin/help.1 /help.1
+COPY --from=operatorbuilder /bin/operator .
+COPY --from=operatorbuilder /bin/LICENSE /licenses/
+COPY --from=operatorbuilder /bin/help.1 /help.1
+
+COPY --from=operatoruibuilder /bin/app .
 
 LABEL name="Synopsys Operator" \
+    maintainer="Synopsys Cloud Native Team" \
     vendor="Synopsys" \
     release.version="$VERSION" \
     summary="Synopsys Operator" \
@@ -57,4 +68,4 @@ LABEL name="Synopsys Operator" \
     release="$VERSION" \
     version="$VERSION"
 
-CMD ./app
+CMD ["./app"]

--- a/Dockerfile-Operator.Dockerfile
+++ b/Dockerfile-Operator.Dockerfile
@@ -1,35 +1,33 @@
-FROM blackducksoftware/synopsys-operator:2019.4.0 as builder
+# Run: "docker run --rm -i hadolint/hadolint < Dockerfile" to ensure best practices!
 
-FROM golang:1.11 as operatorbuilder
+# [STAGE: BUILD OPERATOR]
+FROM golang:1.13-alpine as operatorbuilder
 
 # Set the environment
-ENV GO111MODULE=on
 ENV BP=$GOPATH/src/github.com/blackducksoftware/synopsys-operator
 
 # Add the whole directory
-ADD . $BP
-
-### BUILD THE BINARIES...
-WORKDIR $BP
+COPY . ${BP}
 
 # Container catalog requirements
-COPY ./LICENSE /bin/LICENSE 
+COPY ./LICENSE /bin/LICENSE
 COPY ./help.1 /bin/help.1
 
-# RUN cd cmd/blackduckctl && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/blackduckctl
-RUN cd cmd/operator && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/operator
+WORKDIR ${BP}/cmd/operator
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/operator
 
+
+# [FINAL STAGE]
 FROM scratch
 
-MAINTAINER Synopsys Cloud Native Team
+LABEL maintainer="Synopsys Cloud Native Team"
 
 ARG VERSION
 ARG BUILDTIME
 ARG LASTCOMMIT
 
-COPY --from=builder ./go/src/github.com/blackducksoftware/synopsys-operator/cmd/operator-ui/app . 
-COPY --from=operatorbuilder /bin/operator . 
-COPY --from=operatorbuilder /bin/LICENSE /licenses/ 
+COPY --from=operatorbuilder /bin/operator .
+COPY --from=operatorbuilder /bin/LICENSE /licenses/
 COPY --from=operatorbuilder /bin/help.1 /help.1
 
 LABEL name="Synopsys Operator" \
@@ -43,4 +41,4 @@ LABEL name="Synopsys Operator" \
       release="$VERSION" \
       version="$VERSION"
 
-CMD ./app
+CMD ["./operator"]


### PR DESCRIPTION
- [X] Update Dockerfile to use multi-stage build (previously, for example gobuffalo/buffalo:v0.14.3 was using golang1.12 whereas we're expecting our stuff to run with golang1.13).  Now, building of the ui and the operator happen in separate stages, so it can be maintained easily.
- [X] Use `COPY` instead of `ADD` (https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy)
- [X] Use json list for `CMD` (https://github.com/hadolint/hadolint/wiki/DL3025)
- [X] Update the Dockerfile-Operator for dev purposes

Dockerfile reduces size from `112MB` to `105MB` and Dockerfile-Operator reduces size from `54.1MB` to `49.7MB`... not much, but it's the little wins that count 😄 