### PR TITLE
Verify that the version exist before deployment

### DIFF
--- a/pkg/polaris/creater.go
+++ b/pkg/polaris/creater.go
@@ -23,7 +23,11 @@ package polaris
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
+	"net/url"
+	"path"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,6 +198,22 @@ func GetPolarisBaseSecrets(polaris Polaris) (map[string]runtime.Object, error) {
 	}
 
 	return mapOfUniqueIDToBaseRuntimeObject, nil
+}
+
+func GetVersions(baseURL string) ([]string, error) {
+	serverURL, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("the base url provided is not a valid url")
+	}
+
+	serverURL.Path = path.Join(serverURL.Path, "polaris", "VERSIONS")
+
+	content, err := util.HTTPGet(serverURL.String())
+	if err != nil {
+		return nil, fmt.Errorf("couldn't fetch version list from the remote server: %+v", err)
+	}
+
+	return strings.Split(string(content), "\n"), nil
 }
 
 // GetPolarisReportingComponents get Polaris reporting components

--- a/pkg/synopsysctl/cmd_create.go
+++ b/pkg/synopsysctl/cmd_create.go
@@ -623,6 +623,10 @@ var createPolarisCmd = &cobra.Command{
 			}
 		}
 
+		if err := CheckVersionExists(baseURL, polarisObj.Version); err != nil {
+			return err
+		}
+
 		if err := ensurePolaris(polarisObj, false, true); err != nil {
 			return err
 		}
@@ -679,6 +683,10 @@ var createPolarisNativeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		polarisObj, err := updatePolarisSpecWithFlags(cmd, namespace)
 		if err != nil {
+			return err
+		}
+
+		if err := CheckVersionExists(baseURL, polarisObj.Version); err != nil {
 			return err
 		}
 

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -1281,6 +1281,9 @@ var updatePolarisCmd = &cobra.Command{
 			return err
 		}
 
+		if err := CheckVersionExists(baseURL, newPolaris.Version); err != nil {
+			return err
+		}
 		if err := ensurePolaris(newPolaris, true, createOrganization); err != nil {
 			return err
 		}

--- a/pkg/synopsysctl/polaris.go
+++ b/pkg/synopsysctl/polaris.go
@@ -229,3 +229,24 @@ func ensurePolaris(polarisObj *polaris.Polaris, isUpdate bool, createOrganizatio
 	//}
 	return nil
 }
+
+func CheckVersionExists(baseURL string, version string) error {
+	versions, err := polaris.GetVersions(baseURL)
+	if err != nil {
+		return err
+	}
+
+	if !IsInStringSlice(versions, version) {
+		return fmt.Errorf("only the following Polaris versions are supported %v", versions)
+	}
+	return nil
+}
+
+func IsInStringSlice(slice []string, search string) bool {
+	for _, v := range slice {
+		if v == search {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
#785
Synopsysctl will now print the supported versions if we try to deploy a Polaris version that doesn't exist.