### PR TITLE
get and update master key command changes

### DIFF
--- a/pkg/api/blackduck/v1/types.go
+++ b/pkg/api/blackduck/v1/types.go
@@ -78,6 +78,7 @@ type BlackduckSpec struct {
 	AdminPassword         string                     `json:"adminPassword"`
 	UserPassword          string                     `json:"userPassword"`
 	PostgresPassword      string                     `json:"postgresPassword"`
+	SealKey               string                     `json:"sealKey"`
 }
 
 // Environs will hold the list of Environment variables

--- a/pkg/apps/blackduck/latest/deployer.go
+++ b/pkg/apps/blackduck/latest/deployer.go
@@ -110,7 +110,7 @@ func (hc *Creater) GetComponents(blackduck *blackduckapi.Blackduck) (*api.Compon
 	componentList.ConfigMaps = append(componentList.ConfigMaps, containerCreater.GetConfigmaps()...)
 
 	//Secrets
-	// nginx certificatea
+	// nginx certificate
 	cert, key, _ := hc.getTLSCertKeyOrCreate(blackduck)
 	if !hc.config.DryRun {
 		secret, err := util.GetSecret(hc.kubeClient, hc.config.Namespace, "blackduck-secret")
@@ -118,7 +118,17 @@ func (hc *Creater) GetComponents(blackduck *blackduckapi.Blackduck) (*api.Compon
 			log.Errorf("unable to find Synopsys Operator blackduck-secret in %s namespace due to %+v", hc.config.Namespace, err)
 			return nil, err
 		}
-		componentList.Secrets = append(componentList.Secrets, containerCreater.GetSecrets(cert, key, secret.Data["SEAL_KEY"])...)
+
+		// if Black Duck instance level Seal Key is provided, then use it else use the operator level seal key
+		sealKey := secret.Data["SEAL_KEY"]
+		if len(blackduck.Spec.SealKey) > 0 {
+			sealKeyStr, err := util.Base64Decode(blackduck.Spec.SealKey)
+			if err != nil {
+				return nil, fmt.Errorf("%v: unable to decode seal key due to: %+v", blackduck.Spec.Namespace, err)
+			}
+			sealKey = []byte(sealKeyStr)
+		}
+		componentList.Secrets = append(componentList.Secrets, containerCreater.GetSecrets(cert, key, sealKey)...)
 	} else {
 		componentList.Secrets = append(componentList.Secrets, containerCreater.GetSecrets(cert, key, []byte{})...)
 	}

--- a/pkg/blackduck/ctl_blackduck_test.go
+++ b/pkg/blackduck/ctl_blackduck_test.go
@@ -182,6 +182,7 @@ func TestAddCRSpecFlagsToCommand(t *testing.T) {
 	cmd.Flags().StringVar(&ctl.NodeAffinityFilePath, "node-affinity-file-path", ctl.NodeAffinityFilePath, "Absolute path to a file containing a list of node affinities")
 	cmd.Flags().StringVar(&ctl.Registry, "registry", ctl.Registry, "Name of the registry to use for images e.g. docker.io/blackducksoftware")
 	cmd.Flags().StringSliceVar(&ctl.PullSecrets, "pull-secret-name", ctl.PullSecrets, "Only if the registry requires authentication")
+	cmd.Flags().StringVar(&ctl.SealKey, "seal-key", ctl.SealKey, "Seal key to encrypt the master key when Source code upload is enabled")
 
 	// TODO: Remove this flag in next release
 	cmd.Flags().MarkDeprecated("desired-state", "desired-state flag is deprecated and will be removed by the next release")
@@ -692,6 +693,16 @@ func TestSetCRSpecFieldByFlag(t *testing.T) {
 				LicenseKey:    "changed",
 			},
 			changedSpec: &blackduckapi.BlackduckSpec{LicenseKey: "changed"},
+		},
+		// case
+		{
+			flagName:   "seal-key",
+			initialCtl: NewCRSpecBuilderFromCobraFlags(),
+			changedCtl: &CRSpecBuilderFromCobraFlags{
+				blackDuckSpec: &blackduckapi.BlackduckSpec{},
+				SealKey:       "changed",
+			},
+			changedSpec: &blackduckapi.BlackduckSpec{SealKey: util.Base64Encode([]byte("changed"))},
 		},
 	}
 

--- a/pkg/synopsysctl/polaris.go
+++ b/pkg/synopsysctl/polaris.go
@@ -224,6 +224,7 @@ func ensurePolaris(polarisObj *polaris.Polaris, isUpdate bool) error {
 	return nil
 }
 
+// CheckVersionExists will check whether the Polaris version exist in the GitHub URL
 func CheckVersionExists(baseURL string, version string) error {
 	versions, err := polaris.GetVersions(baseURL)
 	if err != nil {
@@ -236,6 +237,7 @@ func CheckVersionExists(baseURL string, version string) error {
 	return nil
 }
 
+// IsInStringSlice search for a string in a given slice
 func IsInStringSlice(slice []string, search string) bool {
 	for _, v := range slice {
 		if v == search {


### PR DESCRIPTION
* added a seal key at Black Duck instance level
* update master key and update master key native commands are created to update the master key at Black Duck instance level
* if it's update master key command, then 
  * exec into the upload cache container and call the upload cache api to update the master key with new seal key and also provide the stored old master key
  * update the  new seal key in the spec
  * wait for the upload cache container to be restarted for the seal key changes to be reflected
* if it's update master key native command, then
  * exec into the upload cache container and call the upload cache api to update the master key with new seal key and also provide the stored old master key
  * update the  new seal key in the <name>-blackduck-upload-cache secret
  * delete the upload cache container, so that the pod will be restarted for the seal key changes to be reflected

fixes #937 , #682 