### PR TITLE
Change Volume File Ownership Jobs for Security Contexts

### DIFF
--- a/pkg/util/security_context.go
+++ b/pkg/util/security_context.go
@@ -33,10 +33,7 @@ func SetSecurityContextInPodConfig(podConfig *PodConfig, securityContext *Securi
 	if securityContext != nil {
 		podConfig.RunAsUser = securityContext.RunAsUser
 		podConfig.RunAsGroup = securityContext.RunAsGroup
-
-		if !isOpenshift {
-			podConfig.FSGID = securityContext.FsGroup
-		}
+		podConfig.FSGID = securityContext.FsGroup
 	} else {
 		// if not openshift and the user doesn't specify a securityContext, then FSGID still needs to be set to 0
 		if !isOpenshift {


### PR DESCRIPTION
synopsyctl creates jobs to change ownership in Volumes when Security Contexts are enabled/changed