### PR TITLE
Support for Black Duck 2019.12.1 and Alert 5.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/onsi/gomega v1.5.0
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openshift/client-go v3.9.0+incompatible
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3

--- a/pkg/apps/alert/latest/alert_versions.go
+++ b/pkg/apps/alert/latest/alert_versions.go
@@ -53,6 +53,10 @@ var imageTags = map[string]map[string]string{
 		"blackduck-alert": "5.1.0",
 		"blackduck-cfssl": "1.0.0",
 	},
+	"5.2.0": {
+		"blackduck-alert": "5.2.0",
+		"blackduck-cfssl": "1.0.0",
+	},
 }
 
 // GetImageTag returns the url for an image

--- a/pkg/apps/blackduck/blackduck.go
+++ b/pkg/apps/blackduck/blackduck.go
@@ -110,7 +110,7 @@ func (b *Blackduck) ensureVersion(bd *blackduckapi.Blackduck) error {
 	if len(bd.Spec.Version) == 0 {
 		// TODO: fix the sort logic for Black Duck version
 		// sort.Sort(sort.Reverse(sort.StringSlice(versions)))
-		bd.Spec.Version = "2019.10.3"
+		bd.Spec.Version = "2019.12.1"
 	} else {
 		// If the verion is provided, check that it's supported
 		for _, v := range versions {

--- a/pkg/apps/blackduck/latest/containers/imageTags.go
+++ b/pkg/apps/blackduck/latest/containers/imageTags.go
@@ -24,6 +24,21 @@ package containers
 import "fmt"
 
 var imageTags = map[string]map[string]string{
+	"2019.12.1": {
+		"blackduck-authentication": "2019.12.1",
+		"blackduck-documentation":  "2019.12.1",
+		"blackduck-jobrunner":      "2019.12.1",
+		"blackduck-registration":   "2019.12.1",
+		"blackduck-scan":           "2019.12.1",
+		"blackduck-webapp":         "2019.12.1",
+		"blackduck-cfssl":          "1.0.1",
+		"blackduck-logstash":       "1.0.5",
+		"blackduck-nginx":          "1.0.14",
+		"blackduck-zookeeper":      "1.0.3",
+		"blackduck-upload-cache":   "1.0.12",
+		"appcheck-worker":          "2019.12",
+		"rabbitmq":                 "1.0.3",
+	},
 	"2019.12.0": {
 		"blackduck-authentication": "2019.12.0",
 		"blackduck-documentation":  "2019.12.0",

--- a/pkg/synopsysctl/cmd_create.go
+++ b/pkg/synopsysctl/cmd_create.go
@@ -395,7 +395,7 @@ var createBlackDuckCmd = &cobra.Command{
 				// versions := apps.NewApp(&protoform.Config{}, restconfig).Blackduck().Versions()
 				// sort.Sort(sort.Reverse(sort.StringSlice(versions)))
 				// TODO: fix the sort logic for Black Duck version
-				blackDuck.Spec.Version = "2019.10.3"
+				blackDuck.Spec.Version = "2019.12.1"
 			}
 			versionSupportsSecurityContexts, err := util.IsVersionGreaterThanOrEqualTo(blackDuck.Spec.Version, 2019, time.December, 0)
 			if err != nil {
@@ -418,7 +418,7 @@ var createBlackDuckCmd = &cobra.Command{
 			// versions := apps.NewApp(&protoform.Config{}, restconfig).Blackduck().Versions()
 			// sort.Sort(sort.Reverse(sort.StringSlice(versions)))
 			// TODO: fix the sort logic for Black Duck version
-			blackDuck.Spec.Version = "2019.10.3"
+			blackDuck.Spec.Version = "2019.12.1"
 		}
 		versionSupportsSecurityContexts, err := util.IsVersionGreaterThanOrEqualTo(blackDuck.Spec.Version, 2019, time.December, 0)
 		if err != nil {


### PR DESCRIPTION
resolves #1200 and #1221
