### PR TITLE
add function to parse a registry from an image

### DIFF
--- a/pkg/util/imageparser.go
+++ b/pkg/util/imageparser.go
@@ -26,7 +26,7 @@ import (
 	"regexp"
 )
 
-var imageTagRegexp = regexp.MustCompile(`([0-9a-zA-Z-_:\\.]*)/([0-9a-zA-Z-_:\\.]*):([a-zA-Z0-9-\\._]+)$`)
+var imageTagRegexp = regexp.MustCompile(`([0-9a-zA-Z-_:/\\.]+)/([0-9a-zA-Z-_:\\.]+):([a-zA-Z0-9-\\._]+)$`)
 var imageVersionRegexp = regexp.MustCompile(`([0-9]+).([0-9]+).([0-9]+)$`)
 
 // ValidateImageString takes a docker image string and returns substring submatch if it's valid, and an error if it is not; Example:
@@ -69,4 +69,16 @@ func GetImageName(image string) (string, error) {
 	}
 	name := imageSubstringSubmatch[len(imageSubstringSubmatch)-2]
 	return name, nil
+}
+
+// GetImageRegistry takes a docker image string and returns the registry
+func GetImageRegistry(image string) (string, error) {
+	imageSubstringSubmatch, err := ValidateImageString(image)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("%s\n", imageSubstringSubmatch)
+	// registry := strings.Join(imageSubstringSubmatch[0:len(imageSubstringSubmatch)-2], "")
+	registry := imageSubstringSubmatch[len(imageSubstringSubmatch)-3]
+	return registry, nil
 }

--- a/pkg/util/imageparser_test.go
+++ b/pkg/util/imageparser_test.go
@@ -243,3 +243,42 @@ func TestGetImageName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetImageRegistry(t *testing.T) {
+	testcases := []struct {
+		description      string
+		image            string
+		expectedRegistry string
+	}{
+		{
+			description:      "standard image format",
+			image:            "repo/name:tag",
+			expectedRegistry: "repo",
+		},
+		{
+			description:      "registry has a .",
+			image:            "docker.io/blackducksoftware/blackduck-cfssl:1.0.0",
+			expectedRegistry: "docker.io/blackducksoftware",
+		},
+		{
+			description:      "registry has a :",
+			image:            "url.com:80/name:tag",
+			expectedRegistry: "url.com:80",
+		},
+		{
+			description:      "registry has a /",
+			image:            "url/com:80/name:tag",
+			expectedRegistry: "url/com:80",
+		},
+	}
+
+	for _, tc := range testcases {
+		gotRegistry, err := GetImageRegistry(tc.image)
+		if err != nil {
+			t.Errorf("Test Case '%s' failed...\nError: %s", tc.description, err)
+		}
+		if gotRegistry != tc.expectedRegistry {
+			t.Errorf("Test Case '%s' failed...\nError: %s != %s", tc.description, gotRegistry, tc.expectedRegistry)
+		}
+	}
+}


### PR DESCRIPTION
This is useful for --image-registries in the Alert helm chart. It can also be used for the other apps