### PR TITLE
fix helm upgrade with new version of charts

### DIFF
--- a/pkg/polaris/ctl_polaris.go
+++ b/pkg/polaris/ctl_polaris.go
@@ -80,7 +80,7 @@ type FlagTree struct {
 // NewHelmValuesFromCobraFlags returns an initialized HelmValuesFromCobraFlags
 func NewHelmValuesFromCobraFlags() *HelmValuesFromCobraFlags {
 	return &HelmValuesFromCobraFlags{
-		args:     map[string]interface{}{},
+		args:     make(map[string]interface{}, 0),
 		flagTree: FlagTree{},
 	}
 }
@@ -88,6 +88,13 @@ func NewHelmValuesFromCobraFlags() *HelmValuesFromCobraFlags {
 // GetArgs returns the map of helm chart fields to values
 func (ctl *HelmValuesFromCobraFlags) GetArgs() map[string]interface{} {
 	return ctl.args
+}
+
+// SetArgs set the map to values
+func (ctl *HelmValuesFromCobraFlags) SetArgs(args map[string]interface{}) {
+	for key, value := range args {
+		ctl.args[key] = value
+	}
 }
 
 // AddCobraFlagsToCommand adds flags for the Polaris helm chart to the cmd
@@ -178,7 +185,7 @@ func (ctl *HelmValuesFromCobraFlags) GenerateHelmFlagsFromCobraFlags(flagset *pf
 		return nil, err
 	}
 	var isErrorExist bool
-	ctl.args["global"] = map[string]interface{}{"environment": "onprem"}
+	util.SetHelmValueInMap(ctl.args, []string{"global", "environment"}, "onprem")
 	flagset.VisitAll(func(f *pflag.Flag) {
 		if f.Changed {
 			log.Debugf("flag '%s': CHANGED", f.Name)

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -1322,6 +1322,11 @@ var updatePolarisCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		helmRelease, err := util.GetWithHelm3(polarisName, namespace, kubeConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to get previous user defined values: %+v", err)
+		}
+		updatePolarisCobraHelper.SetArgs(helmRelease.Config)
 		// Get the flags to set Helm values
 		helmValuesMap, err := updatePolarisCobraHelper.GenerateHelmFlagsFromCobraFlags(cmd.Flags())
 		if err != nil {
@@ -1366,6 +1371,12 @@ var updatePolarisReportingCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		helmRelease, err := util.GetWithHelm3(polarisReportingName, namespace, kubeConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to get previous user defined values: %+v", err)
+		}
+		updatePolarisReportingCobraHelper.SetArgs(helmRelease.Config)
+
 		// Get the flags to set Helm values
 		helmValuesMap, err := updatePolarisReportingCobraHelper.GenerateHelmFlagsFromCobraFlags(cmd.Flags())
 		if err != nil {

--- a/pkg/util/helm_helpers.go
+++ b/pkg/util/helm_helpers.go
@@ -127,7 +127,7 @@ func UpdateWithHelm3(releaseName, namespace, chartURL string, vals map[string]in
 		client.Version = ">0.0.0-0"
 	}
 	client.Namespace = namespace
-	client.ReuseValues = true                     // rememeber the values that have been set previously
+	client.ResetValues = true                     // rememeber the values that have been set previously
 	_, err = client.Run(releaseName, chart, vals) // updates the release in the namespace from the actionConfig
 	if err != nil {
 		return fmt.Errorf("failed to run upgrade: %+v", err)

--- a/pkg/util/helm_helpers.go
+++ b/pkg/util/helm_helpers.go
@@ -127,7 +127,7 @@ func UpdateWithHelm3(releaseName, namespace, chartURL string, vals map[string]in
 		client.Version = ">0.0.0-0"
 	}
 	client.Namespace = namespace
-	client.ResetValues = true                     // rememeber the values that have been set previously
+	client.ResetValues = true                     // reset values always to apply the new chart value
 	_, err = client.Run(releaseName, chart, vals) // updates the release in the namespace from the actionConfig
 	if err != nil {
 		return fmt.Errorf("failed to run upgrade: %+v", err)


### PR DESCRIPTION
# resolves CLOUD-697

As per Helm,
during upgrade to new version, we need to use reset-values flags, so that it will set the new values from the new chart and during update/override flags of an existing version, we need use reuse-values.

I have fixed this issue by always get the set values and then use reset values for both upgrading and updating scenario