### PR TITLE
CRUD tweaks to help messages and required flags

### DIFF
--- a/pkg/synopsysctl/cmd_create.go
+++ b/pkg/synopsysctl/cmd_create.go
@@ -243,8 +243,8 @@ func checkSealKey(flagset *pflag.FlagSet) {
 
 // createBlackDuckCmd creates a Black Duck instance
 var createBlackDuckCmd = &cobra.Command{
-	Use:           "blackduck NAME",
-	Example:       "synopsysctl create blackduck <name>\nsynopsysctl create blackduck <name> -n <namespace>\nsynopsysctl create blackduck <name> --mock json",
+	Use:           "blackduck NAME -n NAMESPACE",
+	Example:       "synopsysctl create blackduck <name> -n <namespace>",
 	Short:         "Create a Black Duck instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -252,7 +252,7 @@ var createBlackDuckCmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 1 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 1 argument")
+			return fmt.Errorf("this command takes 1 argument, but got %+v", args)
 		}
 		checkPasswords(cmd.Flags())
 		cobra.MarkFlagRequired(cmd.Flags(), "certificate-file-path")
@@ -310,8 +310,8 @@ var createBlackDuckCmd = &cobra.Command{
 
 // createBlackDuckNativeCmd prints the Kubernetes resources for creating a Black Duck instance
 var createBlackDuckNativeCmd = &cobra.Command{
-	Use:           "native NAME",
-	Example:       "synopsysctl create blackduck native <name>\nsynopsysctl create blackduck native <name> -n <namespace>\nsynopsysctl create blackduck native <name> -o yaml",
+	Use:           "native NAME -n NAMESPACE",
+	Example:       "synopsysctl create blackduck native <name> -n <namespace>",
 	Short:         "Print the Kubernetes resources for creating a Black Duck instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -319,7 +319,7 @@ var createBlackDuckNativeCmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 1 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 1 arguments")
+			return fmt.Errorf("this command takes 1 argument, but got %+v", args)
 		}
 		checkPasswords(cmd.Flags())
 		cobra.MarkFlagRequired(cmd.Flags(), "certificate-file-path")
@@ -486,7 +486,7 @@ var createOpsSightNativeCmd = &cobra.Command{
 
 // createPolarisCmd creates a Polaris instance
 var createPolarisCmd = &cobra.Command{
-	Use:           "polaris",
+	Use:           "polaris -n NAMESPACE",
 	Short:         "Create a Polaris instance. (Please make sure you have read and understand prerequisites before installing Polaris: https://sig-confluence.internal.synopsys.com/display/DD/Polaris+on-premises])",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -537,7 +537,7 @@ var createPolarisCmd = &cobra.Command{
 
 // createPolarisNativeCmd prints the Kubernetes resources for creating a Polaris instance
 var createPolarisNativeCmd = &cobra.Command{
-	Use:           "native",
+	Use:           "native -n NAMESPACE",
 	Short:         "Print Kubernetes resources for creating a Polaris instance (Please make sure you have read and understand prerequisites before installing Polaris: https://sig-confluence.internal.synopsys.com/display/DD/Polaris+on-premises])",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -546,7 +546,7 @@ var createPolarisNativeCmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 0 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 0 argument, but got %+v", args)
+			return fmt.Errorf("this command takes 0 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -602,8 +602,8 @@ func polarisPostgresCheck(flagset *pflag.FlagSet) error {
 
 // createPolarisReportingCmd creates a Polaris-Reporting instance
 var createPolarisReportingCmd = &cobra.Command{
-	Use:           "polaris-reporting",
-	Example:       "",
+	Use:           "polaris-reporting -n NAMESPACE",
+	Example:       "synopsysctl create polaris-reporting -n <namespace>",
 	Short:         "Create a Polaris-Reporting instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -670,8 +670,8 @@ var createPolarisReportingCmd = &cobra.Command{
 
 // createPolarisReportingNativeCmd prints Polaris-Reporting resources
 var createPolarisReportingNativeCmd = &cobra.Command{
-	Use:           "native",
-	Example:       "",
+	Use:           "native -n NAMESPACE",
+	Example:       "synopsysctl create polaris-reporting native -n <namespace>",
 	Short:         "Print Kubernetes resources for creating a Polaris-Reporting instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -679,7 +679,7 @@ var createPolarisReportingNativeCmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 0 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 0 argument, but got %+v", args)
+			return fmt.Errorf("this command takes 0 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -729,8 +729,8 @@ var createPolarisReportingNativeCmd = &cobra.Command{
 
 // createBDBACmd creates a BDBA instance
 var createBDBACmd = &cobra.Command{
-	Use:           "bdba",
-	Example:       "",
+	Use:           "bdba -n NAMESPACE",
+	Example:       "synopsysctl create bdba -n <namespace>",
 	Short:         "Create a BDBA instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -780,8 +780,8 @@ var createBDBACmd = &cobra.Command{
 
 // createBDBANativeCmd prints BDBA resources
 var createBDBANativeCmd = &cobra.Command{
-	Use:           "native",
-	Example:       "",
+	Use:           "native -n NAMESPACE",
+	Example:       "synopsysctl create bdba -n <namespace>",
 	Short:         "Print Kubernetes resources for creating a BDBA instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -853,7 +853,6 @@ func init() {
 	createCmd.AddCommand(createBlackDuckCmd)
 
 	createBlackDuckCobraHelper.AddCRSpecFlagsToCommand(createBlackDuckNativeCmd, true)
-	addNativeFormatFlag(createBlackDuckNativeCmd)
 	addChartLocationPathFlag(createBlackDuckNativeCmd)
 	createBlackDuckCmd.AddCommand(createBlackDuckNativeCmd)
 

--- a/pkg/synopsysctl/cmd_delete.go
+++ b/pkg/synopsysctl/cmd_delete.go
@@ -23,6 +23,7 @@ package synopsysctl
 
 import (
 	"fmt"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	polarisreporting "github.com/blackducksoftware/synopsys-operator/pkg/polaris-reporting"
@@ -76,15 +77,15 @@ var deleteAlertCmd = &cobra.Command{
 
 // deleteBlackDuckCmd deletes Black Duck instances from the cluster
 var deleteBlackDuckCmd = &cobra.Command{
-	Use:           "blackduck NAME",
+	Use:           "blackduck NAME -n NAMESPACE",
 	Example:       "synopsysctl delete blackduck <name> -n <namespace>",
-	Short:         "Delete one or many Black Duck instances",
+	Short:         "Delete a Black Duck instances",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 1 or more arguments")
+			return fmt.Errorf("this command takes 1 argument, but got %+v", args)
 		}
 		return nil
 	},
@@ -137,7 +138,7 @@ var deleteOpsSightCmd = &cobra.Command{
 
 // deletePolarisCmd deletes a Polaris instance
 var deletePolarisCmd = &cobra.Command{
-	Use:           "polaris",
+	Use:           "polaris -n NAMESPACE",
 	Example:       "synopsysctl delete polaris -n <namespace>",
 	Short:         "Delete a Polaris instance",
 	SilenceUsage:  true,
@@ -146,7 +147,7 @@ var deletePolarisCmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 0 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 0 argument, but got %+v", args)
+			return fmt.Errorf("this command takes 0 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -164,7 +165,7 @@ var deletePolarisCmd = &cobra.Command{
 
 // deletePolarisReportingCmd deletes a Polaris-Reporting instance
 var deletePolarisReportingCmd = &cobra.Command{
-	Use:           "polaris-reporting",
+	Use:           "polaris-reporting -n NAMESPACE",
 	Example:       "synopsysctl delete polaris-reportinng -n <namespace>",
 	Short:         "Delete a Polaris-Reporting instance",
 	SilenceUsage:  true,
@@ -173,7 +174,7 @@ var deletePolarisReportingCmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 0 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 0 argument, but got %+v", args)
+			return fmt.Errorf("this command takes 0 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -203,7 +204,7 @@ var deletePolarisReportingCmd = &cobra.Command{
 
 // deleteBDBACmd deletes a BDBA instance
 var deleteBDBACmd = &cobra.Command{
-	Use:           "bdba",
+	Use:           "bdba -n NAMESPACE",
 	Example:       "synopsysctl delete bdba -n <namespace>",
 	Short:         "Delete a BDBA instance",
 	SilenceUsage:  true,
@@ -212,7 +213,7 @@ var deleteBDBACmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 0 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 0 argument, but got %+v", args)
+			return fmt.Errorf("this command takes 0 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -240,6 +241,7 @@ func init() {
 
 	// Add Delete Black Duck Command
 	deleteBlackDuckCmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
+	cobra.MarkFlagRequired(deleteBlackDuckCmd.Flags(), "namespace")
 	deleteCmd.AddCommand(deleteBlackDuckCmd)
 
 	// Add Delete OpsSight Command

--- a/pkg/synopsysctl/cmd_get.go
+++ b/pkg/synopsysctl/cmd_get.go
@@ -24,12 +24,13 @@ package synopsysctl
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/blackducksoftware/synopsys-operator/pkg/util"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/blackducksoftware/synopsys-operator/pkg/util"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 // Get Command flag for -output functionality
@@ -94,18 +95,18 @@ var getAlertCmd = &cobra.Command{
 	},
 }
 
-// getBlackDuckCmd display one or many Black Duck instances
+// getBlackDuckCmd display a Black Duck instances
 var getBlackDuckCmd = &cobra.Command{
-	Use:           "blackduck [NAME...]",
+	Use:           "blackduck NAME -n NAMESPACE",
 	Example:       "synopsysctl get blackduck <name> -n <namespace>",
 	Aliases:       []string{"blackducks"},
-	Short:         "Display one or many Black Duck instances",
+	Short:         "Display a Black Duck instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 1 arguments")
+			return fmt.Errorf("this command takes 1 argument, but got %+v", args)
 		}
 		return nil
 	},
@@ -122,7 +123,7 @@ var getBlackDuckCmd = &cobra.Command{
 
 // getBlackDuckRootKeyCmd get Black Duck master key for source code upload in the cluster
 var getBlackDuckRootKeyCmd = &cobra.Command{
-	Use:           "masterkey BLACK_DUCK_NAME DIRECTORY_PATH_TO_STORE_MASTER_KEY -n NAMESPACE",
+	Use:           "masterkey NAME DIRECTORY_PATH_TO_STORE_MASTER_KEY -n NAMESPACE",
 	Example:       "synopsysctl get blackduck masterkey <name> <directory path to store the master key> -n <namespace>",
 	Short:         "Get the master key of the Black Duck instance that is used for source code upload and store it in the host",
 	SilenceUsage:  true,
@@ -130,7 +131,7 @@ var getBlackDuckRootKeyCmd = &cobra.Command{
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 2 arguments")
+			return fmt.Errorf("this command takes 2 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -197,18 +198,14 @@ var getOpsSightCmd = &cobra.Command{
 
 // getPolarisCmd display the Polaris  instance
 var getPolarisCmd = &cobra.Command{
-	Use:           "polaris",
+	Use:           "polaris -n NAMESPACE",
 	Example:       "synopsysctl get polaris -n <namespace>",
 	Short:         "Display the polaris instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
-			return fmt.Errorf("this command takes 0 arguments")
-		}
-
-		if !cmd.Flags().Lookup("namespace").Changed {
-			return fmt.Errorf("a namespace must be specified using the --namespace flag")
+			return fmt.Errorf("this command takes 0 arguments but got %+v", len(args))
 		}
 		return nil
 	},
@@ -225,14 +222,14 @@ var getPolarisCmd = &cobra.Command{
 
 // getPolarisReportingCmd display the Polaris Reporting instance
 var getPolarisReportingCmd = &cobra.Command{
-	Use:           "polaris-reporting",
+	Use:           "polaris-reporting -n NAMESPACE",
 	Example:       "synopsysctl get polaris-reporting -n <namespace>",
 	Short:         "Display the polaris-reporting instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
-			return fmt.Errorf("this command takes 0 arguments")
+			return fmt.Errorf("this command takes 0 arguments but got %+v", len(args))
 		}
 		return nil
 	},
@@ -249,14 +246,14 @@ var getPolarisReportingCmd = &cobra.Command{
 
 // getBDBACmd display the BDBA instance
 var getBDBACmd = &cobra.Command{
-	Use:           "bdba",
+	Use:           "bdba -n NAMESPACE",
 	Example:       "synopsysctl get bdba -n <namespace>",
 	Short:         "Display the BDBA instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
-			return fmt.Errorf("this command takes 0 arguments")
+			return fmt.Errorf("this command takes 0 arguments but got %+v", len(args))
 		}
 		return nil
 	},
@@ -283,10 +280,11 @@ func init() {
 	getCmd.AddCommand(getAlertCmd)
 
 	// Black Duck
-	getBlackDuckCmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
-	getBlackDuckRootKeyCmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
-	getBlackDuckCmd.AddCommand(getBlackDuckRootKeyCmd)
+	getBlackDuckCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
+	cobra.MarkFlagRequired(getBlackDuckCmd.PersistentFlags(), "namespace")
 	getCmd.AddCommand(getBlackDuckCmd)
+
+	getBlackDuckCmd.AddCommand(getBlackDuckRootKeyCmd)
 
 	// OpsSight
 	getOpsSightCmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
@@ -297,6 +295,7 @@ func init() {
 
 	// Polaris
 	getPolarisCmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
+	cobra.MarkFlagRequired(getPolarisCmd.Flags(), "namespace")
 	getCmd.AddCommand(getPolarisCmd)
 
 	// Polaris Reporting

--- a/pkg/synopsysctl/cmd_start.go
+++ b/pkg/synopsysctl/cmd_start.go
@@ -23,6 +23,7 @@ package synopsysctl
 
 import (
 	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/blackducksoftware/synopsys-operator/pkg/util"
@@ -90,7 +91,7 @@ var startAlertCmd = &cobra.Command{
 
 // startBlackDuckCmd starts a Black Duck instance
 var startBlackDuckCmd = &cobra.Command{
-	Use:           "blackduck NAME",
+	Use:           "blackduck NAME -n NAMESPACE",
 	Example:       "synopsysctl start blackduck <name> -n <namespace>",
 	Short:         "Start a Black Duck instance",
 	SilenceUsage:  true,
@@ -98,7 +99,7 @@ var startBlackDuckCmd = &cobra.Command{
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			cmd.Help()
-			return fmt.Errorf("this command takes one or more arguments")
+			return fmt.Errorf("this command takes 1 argument, but got %+v", args)
 		}
 		return nil
 	},
@@ -184,8 +185,9 @@ func init() {
 	startCmd.AddCommand(startAlertCmd)
 
 	startBlackDuckCmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
-	startCmd.AddCommand(startBlackDuckCmd)
+	cobra.MarkFlagRequired(startBlackDuckCmd.Flags(), "namespace")
 	addChartLocationPathFlag(startBlackDuckCmd)
+	startCmd.AddCommand(startBlackDuckCmd)
 
 	startOpsSightCmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
 	startCmd.AddCommand(startOpsSightCmd)

--- a/pkg/synopsysctl/cmd_stop.go
+++ b/pkg/synopsysctl/cmd_stop.go
@@ -96,15 +96,15 @@ var stopAlertCmd = &cobra.Command{
 
 // stopBlackDuckCmd stops a Black Duck instance
 var stopBlackDuckCmd = &cobra.Command{
-	Use:           "blackduck NAME",
-	Example:       "synopsysctl stop blackduck <name>\nsynopsysctl stop blackduck <name1> <name2>\nsynopsysctl stop blackduck <name> -n <namespace>\nsynopsysctl stop blackduck <name1> <name2> -n <namespace>",
+	Use:           "blackduck NAME -n NAMESPACE",
+	Example:       "synopsysctl stop blackduck <name> -n <namespace>",
 	Short:         "Stop a Black Duck instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			cmd.Help()
-			return fmt.Errorf("this command takes one or more arguments")
+			return fmt.Errorf("this command takes 1 argument, but got %+v", args)
 		}
 		return nil
 	},
@@ -193,8 +193,9 @@ func init() {
 	stopCmd.AddCommand(stopAlertCmd)
 
 	stopBlackDuckCmd.Flags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
-	stopCmd.AddCommand(stopBlackDuckCmd)
+	cobra.MarkFlagRequired(stopBlackDuckCmd.Flags(), "namespace")
 	addChartLocationPathFlag(stopBlackDuckCmd)
+	stopCmd.AddCommand(stopBlackDuckCmd)
 
 	stopCmd.AddCommand(stopOpsSightCmd)
 }

--- a/pkg/synopsysctl/cmd_update.go
+++ b/pkg/synopsysctl/cmd_update.go
@@ -176,14 +176,14 @@ var updateAlertCmd = &cobra.Command{
 
 // updateBlackDuckCmd updates a Black Duck instance
 var updateBlackDuckCmd = &cobra.Command{
-	Use:           "blackduck NAME",
+	Use:           "blackduck NAME -n NAMESPACE",
 	Example:       "synopsyctl update blackduck <name> -n <namespace> --size medium",
 	Short:         "Update a Black Duck instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return fmt.Errorf("this command takes 1 or more arguments")
+		if len(args) != 1 {
+			return fmt.Errorf("this command takes 1 argument, but got %+v", args)
 		}
 		return nil
 	},
@@ -347,14 +347,14 @@ func setBlackDuckFileOwnershipJob(namespace string, name string, pvcName string,
 // updateBlackDuckMasterKeyCmd create new Black Duck master key for source code upload in the cluster
 var updateBlackDuckMasterKeyCmd = &cobra.Command{
 	Use:           "masterkey BLACK_DUCK_NAME DIRECTORY_PATH_OF_STORED_MASTER_KEY NEW_SEAL_KEY -n NAMESPACE",
-	Example:       "synopsysctl update blackduck masterkey <Black Duck name> <directory path of the stored master key> <new seal key> -n <namespace>",
+	Example:       "synopsysctl update blackduck masterkey <name> <directory path of the stored master key> <new seal key> -n <namespace>",
 	Short:         "Update the master key of the Black Duck instance that is used for source code upload",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 3 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 3 arguments")
+			return fmt.Errorf("this command takes 3 arguments, but got %+v", args)
 		}
 
 		if len(args[2]) != 32 {
@@ -376,15 +376,15 @@ var updateBlackDuckMasterKeyCmd = &cobra.Command{
 
 // updateBlackDuckMasterKeyNativeCmd create new Black Duck master key for source code upload in the cluster
 var updateBlackDuckMasterKeyNativeCmd = &cobra.Command{
-	Use:           "native BLACK_DUCK_NAME DIRECTORY_PATH_OF_STORED_MASTER_KEY NEW_SEAL_KEY -n NAMESPACE",
-	Example:       "synopsysctl update blackduck masterkey native <Black Duck name> <directory path of the stored master key> <new seal key> -n <namespace>",
+	Use:           "native NAME DIRECTORY_PATH_OF_STORED_MASTER_KEY NEW_SEAL_KEY -n NAMESPACE",
+	Example:       "synopsysctl update blackduck masterkey native <name> <directory path of the stored master key> <new seal key> -n <namespace>",
 	Short:         "Update the master key of the Black Duck instance that is used for source code upload",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 3 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 3 arguments")
+			return fmt.Errorf("this command takes 3 arguments, but got %+v", args)
 		}
 
 		if len(args[2]) != 32 {
@@ -465,15 +465,15 @@ func updateMasterKey(namespace string, name string, oldMasterKeyFilePath string,
 
 // updateBlackDuckAddEnvironCmd adds an Environment Variable to a Black Duck instance
 var updateBlackDuckAddEnvironCmd = &cobra.Command{
-	Use:           "addenviron BLACK_DUCK_NAME (ENVIRON_NAME:ENVIRON_VALUE)",
-	Example:       "synopsysctl update blackduck addenviron <name> USE_ALERT:1\nsynopsysctl update blackduck addenviron <name> USE_ALERT:1 -n <namespace>",
+	Use:           "addenviron NAME (ENVIRON_NAME:ENVIRON_VALUE) -n NAMESPACE",
+	Example:       "synopsysctl update blackduck addenviron <name> USE_ALERT:1 -n <namespace>",
 	Short:         "Add an Environment Variable to a Black Duck instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 2 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 2 arguments")
+			return fmt.Errorf("this command takes 2 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -807,7 +807,7 @@ var updateOpsSightAddRegistryNativeCmd = &cobra.Command{
 
 // updatePolarisCmd updates a Polaris instance
 var updatePolarisCmd = &cobra.Command{
-	Use:           "polaris",
+	Use:           "polaris -n NAMESPACE",
 	Example:       "synopsyctl update polaris -n <namespace>",
 	Short:         "Update a Polaris instance. (Please make sure you have read and understand prerequisites before installing Polaris: https://sig-confluence.internal.synopsys.com/display/DD/Polaris+on-premises])",
 	SilenceUsage:  true,
@@ -816,7 +816,7 @@ var updatePolarisCmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 0 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 0 argument, but got %+v", args)
+			return fmt.Errorf("this command takes 0 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -856,8 +856,8 @@ var updatePolarisCmd = &cobra.Command{
 
 // updatePolarisReportingCmd updates a Polaris-Reporting instance
 var updatePolarisReportingCmd = &cobra.Command{
-	Use:           "polaris-reporting",
-	Example:       "",
+	Use:           "polaris-reporting -n NAMESPACE",
+	Example:       "synopsysctl update polaris-reporting -n <namespace>",
 	Short:         "Update a Polaris-Reporting instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -906,8 +906,8 @@ var updatePolarisReportingCmd = &cobra.Command{
 
 // updateBDBACmd updates a BDBA instance
 var updateBDBACmd = &cobra.Command{
-	Use:           "bdba",
-	Example:       "",
+	Use:           "bdba -n NAMESPACE",
+	Example:       "synopsysctl update bdba -n <namespace>",
 	Short:         "Update a BDBA instance",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -915,7 +915,7 @@ var updateBDBACmd = &cobra.Command{
 		// Check the Number of Arguments
 		if len(args) != 0 {
 			cmd.Help()
-			return fmt.Errorf("this command takes 0 argument, but got %+v", args)
+			return fmt.Errorf("this command takes 0 arguments, but got %+v", args)
 		}
 		return nil
 	},
@@ -975,7 +975,7 @@ func init() {
 
 	// updateBlackDuckCmd
 	updateBlackDuckCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", namespace, "Namespace of the instance(s)")
-	cobra.MarkFlagRequired(updateBlackDuckCmd.Flags(), "namespace")
+	cobra.MarkFlagRequired(updateBlackDuckCmd.PersistentFlags(), "namespace")
 	addChartLocationPathFlag(updateBlackDuckCmd)
 	updateBlackDuckCobraHelper.AddCRSpecFlagsToCommand(updateBlackDuckCmd, false)
 	updateCmd.AddCommand(updateBlackDuckCmd)


### PR DESCRIPTION
* Added missing examples to help messages
* Added -n NAMESPACE to commands that require namespace
* Require the namespace flag for commands that missed it
* Fixed wording because synospysctl cannot act on multiple resources at once (only delete 1 blackDuck, etc.)
* Remove the -o yaml flag from BlackDuck Native Command
* Better error message for when command gets too many arguments
